### PR TITLE
FROM centos:7

### DIFF
--- a/hello-world-consumer/Dockerfile
+++ b/hello-world-consumer/Dockerfile
@@ -1,4 +1,9 @@
-FROM strimzi/java-base:latest
+FROM centos:7
+
+RUN yum -y install java-1.8.0-openjdk-headless openssl && yum -y clean all
+
+# Set JAVA_HOME env var
+ENV JAVA_HOME /usr/lib/jvm/java
 
 ARG version=latest
 ENV VERSION ${version}

--- a/hello-world-producer/Dockerfile
+++ b/hello-world-producer/Dockerfile
@@ -1,4 +1,9 @@
-FROM strimzi/java-base:latest
+FROM centos:7
+
+RUN yum -y install java-1.8.0-openjdk-headless openssl && yum -y clean all
+
+# Set JAVA_HOME env var
+ENV JAVA_HOME /usr/lib/jvm/java
 
 ARG version=latest
 ENV VERSION ${version}

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -43,4 +43,11 @@ if [ -z "$JAVA_OPTS" ]; then
     export JAVA_OPTS="${JAVA_OPTS} -Dlog4j.configurationFile=file:bin/log4j2.properties"
 fi
 
-exec /bin/launch_java.sh $1
+
+# Make sure that we use /dev/urandom
+JAVA_OPTS="${JAVA_OPTS} -Dvertx.cacheDirBase=/tmp -Djava.security.egd=file:/dev/./urandom"
+
+# Enable GC logging for memory tracking
+JAVA_OPTS="${JAVA_OPTS} -XX:NativeMemoryTracking=summary -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps"
+
+exec java $JAVA_OPTS -jar $JAR $@


### PR DESCRIPTION
This PR changes the `Dockerfile`s for the producer and consumer to be based directly on `centos:7`, rather than `strimzi/java-base:latest`. We should do this because:

* `strimzi/java-base:latest` is built by a completely different process, so it's not deterministic what the base image actually is. 
* This repo is separate from `strimzi-kafka-operator` because it's supposed to be a more general example of a basic client project. If this repo is to serve as such an example we don't want people copying the dependency on the `java-base` image, which is really internal to `strimzi-kafka-operator`.

