### PR TITLE
Use apps/v1 instead of extensions/v1beta1

### DIFF
--- a/deployment-ssl-auth.yaml
+++ b/deployment-ssl-auth.yaml
@@ -43,7 +43,7 @@ spec:
           name: my-topic
         operation: Describe
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -51,6 +51,9 @@ metadata:
   name: hello-world-producer
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world-producer
   template:
     metadata:
       labels:
@@ -124,7 +127,7 @@ spec:
           name: my-topic-reversed
         operation: Describe
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -132,6 +135,9 @@ metadata:
   name: hello-world-streams
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world-streams
   template:
     metadata:
       labels:
@@ -192,7 +198,7 @@ spec:
           name: hello-world-consumer
         operation: Read
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -200,6 +206,9 @@ metadata:
   name: hello-world-consumer
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world-consumer
   template:
     metadata:
       labels:

--- a/deployment-ssl.yaml
+++ b/deployment-ssl.yaml
@@ -18,7 +18,7 @@ spec:
   replicas: 3
   partitions: 12
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -26,6 +26,9 @@ metadata:
   name: hello-world-producer
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world-producer
   template:
     metadata:
       labels:
@@ -51,7 +54,7 @@ spec:
           - name: MESSAGE_COUNT
             value: "1000"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -59,6 +62,9 @@ metadata:
   name: hello-world-streams
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world-streams
   template:
     metadata:
       labels:
@@ -84,7 +90,7 @@ spec:
             - name: LOG_LEVEL
               value: "INFO"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -92,6 +98,9 @@ metadata:
   name: hello-world-consumer
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world-consumer
   template:
     metadata:
       labels:

--- a/deployment-tracing.yaml
+++ b/deployment-tracing.yaml
@@ -18,7 +18,7 @@ spec:
   replicas: 3
   partitions: 12
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -26,6 +26,9 @@ metadata:
   name: hello-world-producer
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world-producer
   template:
     metadata:
       labels:
@@ -54,7 +57,7 @@ spec:
           - name: JAEGER_SAMPLER_PARAM
             value: "1"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -62,6 +65,9 @@ metadata:
   name: hello-world-streams
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world-streams
   template:
     metadata:
       labels:
@@ -90,7 +96,7 @@ spec:
             - name: JAEGER_SAMPLER_PARAM
               value: "1"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -98,6 +104,9 @@ metadata:
   name: hello-world-consumer
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world-consumer
   template:
     metadata:
       labels:

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -18,7 +18,7 @@ spec:
   replicas: 3
   partitions: 12
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -26,6 +26,9 @@ metadata:
   name: hello-world-producer
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world-producer
   template:
     metadata:
       labels:
@@ -46,7 +49,7 @@ spec:
           - name: MESSAGE_COUNT
             value: "1000"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -54,6 +57,9 @@ metadata:
   name: hello-world-streams
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world-streams
   template:
     metadata:
       labels:
@@ -74,7 +80,7 @@ spec:
             - name: LOG_LEVEL
               value: "INFO"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -82,6 +88,9 @@ metadata:
   name: hello-world-consumer
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world-consumer
   template:
     metadata:
       labels:

--- a/hello-world-consumer.yaml
+++ b/hello-world-consumer.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -6,6 +6,9 @@ metadata:
   name: hello-world-consumer
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world-consumer
   template:
     metadata:
       labels:

--- a/hello-world-producer.yaml
+++ b/hello-world-producer.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -6,6 +6,9 @@ metadata:
   name: hello-world-producer
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world-producer
   template:
     metadata:
       labels:

--- a/hello-world-streams.yaml
+++ b/hello-world-streams.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -6,6 +6,9 @@ metadata:
   name: hello-world-streams
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world-streams
   template:
     metadata:
       labels:


### PR DESCRIPTION
Kubernetes 1.16 drops support for extensions/v1beta1. We should update our Deployments to apps/v1 to make sure we are compatible.