### PR TITLE
Send by default more than 1000 messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 services:
 - docker
 script:

--- a/deployment-oauth.yaml
+++ b/deployment-oauth.yaml
@@ -78,7 +78,7 @@ spec:
           - name: LOG_LEVEL
             value: "INFO"
           - name: MESSAGE_COUNT
-            value: "1000"
+            value: "1000000"
           - name: OAUTH_CLIENT_ID
             value: hello-world-producer
           - name: OAUTH_CLIENT_SECRET
@@ -243,7 +243,7 @@ spec:
             - name: LOG_LEVEL
               value: "INFO"
             - name: MESSAGE_COUNT
-              value: "1000"
+              value: "1000000"
             - name: OAUTH_CLIENT_ID
               value: hello-world-consumer
             - name: OAUTH_CLIENT_SECRET

--- a/deployment-ssl-auth.yaml
+++ b/deployment-ssl-auth.yaml
@@ -87,7 +87,7 @@ spec:
           - name: LOG_LEVEL
             value: "INFO"
           - name: MESSAGE_COUNT
-            value: "1000"
+            value: "1000000"
 ---
 apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaUser
@@ -242,4 +242,4 @@ spec:
           - name: LOG_LEVEL
             value: "INFO"
           - name: MESSAGE_COUNT
-            value: "1000"
+            value: "1000000"

--- a/deployment-ssl.yaml
+++ b/deployment-ssl.yaml
@@ -52,7 +52,7 @@ spec:
           - name: LOG_LEVEL
             value: "INFO"
           - name: MESSAGE_COUNT
-            value: "1000"
+            value: "1000000"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -124,4 +124,4 @@ spec:
           - name: LOG_LEVEL
             value: "INFO"
           - name: MESSAGE_COUNT
-            value: "1000"
+            value: "1000000"

--- a/deployment-tracing.yaml
+++ b/deployment-tracing.yaml
@@ -47,7 +47,7 @@ spec:
           - name: LOG_LEVEL
             value: "INFO"
           - name: MESSAGE_COUNT
-            value: "1000"
+            value: "1000000"
           - name: JAEGER_SERVICE_NAME
             value: hello-world-producer
           - name: JAEGER_AGENT_HOST
@@ -125,7 +125,7 @@ spec:
             - name: LOG_LEVEL
               value: "INFO"
             - name: MESSAGE_COUNT
-              value: "1000"
+              value: "1000000"
             - name: JAEGER_SERVICE_NAME
               value: hello-world-consumer
             - name: JAEGER_AGENT_HOST

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           - name: LOG_LEVEL
             value: "INFO"
           - name: MESSAGE_COUNT
-            value: "1000"
+            value: "1000000"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -109,4 +109,4 @@ spec:
             - name: LOG_LEVEL
               value: "INFO"
             - name: MESSAGE_COUNT
-              value: "1000"
+              value: "1000000"


### PR DESCRIPTION
The example deployment YAML files right now always send/receive only 1.000 messages and afterwards they exit. This sucks when using them for demos, because the processes will start restarting in the middle of a demo. This PR increases the count to 1.000.000 to make sure they last longer. WDYT @ppatierno?