### PR TITLE
Fix refs to example files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,18 @@ Examples how to deploy Apache Kafka using Strimzi can be found on the [Strimzi w
 
 After successfully building the images (which will cause the images to be pushed to the specified Docker repository) you are ready to deploy the producer and consumer containers along with Kafka and Zookeper.
 
-You can deploy the examples individually by applying [`hello-world-producer.yaml`](./hello-world-producer.yaml), [`hello-world-consumer.yaml`](./hello-world-consumer.yaml) and [`hello-world-streams.yaml`](./hello-world-streams.yaml) files.
+You can deploy the examples individually by applying [`hello-world-producer.yaml`](./java/kafka/hello-world-producer.yaml), [`hello-world-consumer.yaml`](./java/kafka/hello-world-consumer.yaml) and [`hello-world-streams.yaml`](./java/kafka/hello-world-streams.yaml) files.
 This will create Kubernetes `Deployments` with the example image.
 The second option is to apply `deployment.yaml` file.
 This deploys the producer, consumer and streams and also creates the topics they are using.
 
 If you built your own version of these examples, remember to update the `image` field with the path where the image was pushed during the build and it's available (i.e. `<my-docker-org>/hello-world-consumer:latest`).
 
-When using [`deployment.yaml`](./deployment.yaml) file for deployment you can start observing the sending messages in producer container's log and the receiving of messages in consumer container's log.
-It's also available as a [`deployment-ssl.yaml`](./deployment-ssl.yaml) which deploys the same producer and consumer applications but using a TLS encryption and [`deployment-ssl-auth.yaml`](./deployment-ssl-auth.yaml) which uses TLS client authentication and ACLs.
+When using [`deployment.yaml`](./java/kafka/deployment.yaml) file for deployment you can start observing the sending messages in producer container's log and the receiving of messages in consumer container's log.
+It's also available as a [`deployment-ssl.yaml`](./java/kafka/deployment-ssl.yaml) which deploys the same producer and consumer applications but using a TLS encryption and [`deployment-ssl-auth.yaml`](./java/kafka/deployment-ssl-auth.yaml) which uses TLS client authentication and ACLs.
 
-You can also use these example clients with OAuth authentication. See the exmaple [`deployment-oauth.yaml`](./deployment-oauth.yaml) for more details.
-To run the OAuth example, you will need to have your Kafka cluster configured with OAuth and change the configuration in [`deployment-oauth.yaml`](./deployment-oauth.yaml) to point to your OAuth server.
+You can also use these example clients with OAuth authentication. See the exmaple [`deployment-oauth.yaml`](./java/kafka/deployment-oauth.yaml) for more details.
+To run the OAuth example, you will need to have your Kafka cluster configured with OAuth and change the configuration in [`deployment-oauth.yaml`](./java/kafka/deployment-oauth.yaml) to point to your OAuth server.
 
 ## Configuration
 
@@ -89,4 +89,4 @@ Streams
 The examples support tracing using the [OpenTracing Apache Kafka Instrumentation](https://github.com/opentracing-contrib/java-kafka-client) and the [Jaeger project](https://www.jaegertracing.io/).
 To enable tracing, configure the Jaeger Tracer using [environment variables](https://github.com/jaegertracing/jaeger-client-java/tree/master/jaeger-core#configuration-via-environment).
 
-You can also use the provided example in [`deployment-tracing.yaml`](./deployment-tracing.yaml).
+You can also use the provided example in [`deployment-tracing.yaml`](./java/kafka/deployment-tracing.yaml).


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

After https://github.com/strimzi/client-examples/pull/16 the links from readme stopped working.