### PR TITLE
Set MESSAGE_COUNT for consumer/producer deployments

### DIFF
--- a/java/kafka/hello-world-consumer.yaml
+++ b/java/kafka/hello-world-consumer.yaml
@@ -26,3 +26,5 @@ spec:
             value: my-hello-world-consumer
           - name: LOG_LEVEL
             value: "INFO"
+          - name: MESSAGE_COUNT
+            value: "1000000"

--- a/java/kafka/hello-world-producer.yaml
+++ b/java/kafka/hello-world-producer.yaml
@@ -26,3 +26,5 @@ spec:
             value: "1000"
           - name: LOG_LEVEL
             value: "INFO"
+          - name: MESSAGE_COUNT
+            value: "1000000"


### PR DESCRIPTION
Currently the base hello-world consumer/producer use the default message count set to 10 which means that the applications ends after few seconds and they are keep restarting by Kubernetes.
It's not a great user experience.
The complete `deployment.yaml` set an higher message count to avoid that.
This PR proposes to do the same for the hello-world-consumer/producer YAMLs as well.