### PR TITLE
Fix an NPE when no CLIENT_RACK is specified

### DIFF
--- a/java/kafka/hello-world-consumer/src/main/java/KafkaConsumerConfig.java
+++ b/java/kafka/hello-world-consumer/src/main/java/KafkaConsumerConfig.java
@@ -55,7 +55,7 @@ public class KafkaConsumerConfig {
         String bootstrapServers = System.getenv("BOOTSTRAP_SERVERS");
         String topic = System.getenv("TOPIC");
         String groupId = System.getenv("GROUP_ID");
-        String clientRack = System.getenv("CLIENT_RACK");
+        String clientRack = System.getenv("CLIENT_RACK") == null ? null : System.getenv("CLIENT_RACK");
         Long messageCount = System.getenv("MESSAGE_COUNT") == null ? DEFAULT_MESSAGES_COUNT : Long.valueOf(System.getenv("MESSAGE_COUNT"));
         String trustStorePassword = System.getenv("TRUSTSTORE_PASSWORD") == null ? null : System.getenv("TRUSTSTORE_PASSWORD");
         String trustStorePath = System.getenv("TRUSTSTORE_PATH") == null ? null : System.getenv("TRUSTSTORE_PATH");
@@ -74,7 +74,9 @@ public class KafkaConsumerConfig {
         Properties props = new Properties();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBootstrapServers());
         props.put(ConsumerConfig.GROUP_ID_CONFIG, config.getGroupId());
-        props.put(ConsumerConfig.CLIENT_RACK_CONFIG, config.getClientRack());
+        if (config.getClientRack() != null) {
+            props.put(ConsumerConfig.CLIENT_RACK_CONFIG, config.getClientRack());
+        }
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, config.getAutoOffsetReset());
         props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, config.getEnableAutoCommit());
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");


### PR DESCRIPTION
When no CLIENT_RACK is set, an NPE is raised when putting a null value in the Properties bag for consumer configuration.