### PR TITLE
Bump the Jaeger client dependnecy to 1.1

### DIFF
--- a/java/kafka/pom.xml
+++ b/java/kafka/pom.xml
@@ -19,7 +19,7 @@
         <log4j.version>2.11.1</log4j.version>
         <kafka.version>2.4.0</kafka.version>
         <opentracing-kafka.version>0.1.11</opentracing-kafka.version>
-        <jaeger.version>1.0.0</jaeger.version>
+        <jaeger.version>1.1.0</jaeger.version>
         <strimzi-oauth-callback.version>0.3.0</strimzi-oauth-callback.version>
     </properties>
 


### PR DESCRIPTION
In addition to the previous PR, this one bumps the Jaeger Client dependency to 1.1.0.