### PR TITLE
Link for Governance documents to the governance repository

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Strimzi Community Code of Conduct
+
+Strimzi Community Code of Conduct is defined in the [governance repository](https://github.com/strimzi/governance/blob/master/CODE_OF_CONDUCT.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,3 @@
+# Strimzi Governance
+
+Strimzi Governance is defined in the [governance repository](https://github.com/strimzi/governance/blob/master/GOVERNANCE.md).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,3 @@
+# Strimzi Maintainers list
+
+Strimzi Maintainers list is defined in the [governance repository](https://github.com/strimzi/governance/blob/master/MAINTAINERS).


### PR DESCRIPTION
This PR implements the proposal https://github.com/strimzi/strimzi-kafka-operator/blob/master/design/github-repository-restructuring.md. After creating the new repo containing the governance files, we should change the files in this repo and just have them to link to the governance repository.