### PR TITLE
Updated apiversion for Deployment on HTTP examples

### DIFF
--- a/http/vertx/deployment-tracing.yaml
+++ b/http/vertx/deployment-tracing.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -6,6 +6,9 @@ metadata:
   name: kafka-http-producer
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: kafka-http-producer
   template:
     metadata:
       labels:
@@ -39,7 +42,7 @@ spec:
             memory: "256Mi"
             cpu: "250m"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -47,6 +50,9 @@ metadata:
   name: kafka-http-consumer
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: kafka-http-consumer
   template:
     metadata:
       labels:

--- a/http/vertx/kafka-http-consumer.yaml
+++ b/http/vertx/kafka-http-consumer.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -6,6 +6,9 @@ metadata:
   name: kafka-http-consumer
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: kafka-http-consumer
   template:
     metadata:
       labels:

--- a/http/vertx/kafka-http-producer.yaml
+++ b/http/vertx/kafka-http-producer.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -6,6 +6,9 @@ metadata:
   name: kafka-http-producer
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: kafka-http-producer
   template:
     metadata:
       labels:


### PR DESCRIPTION
This trivial PR just updates the apiVersion for Deployments in HTTP examples.