### PR TITLE
Increment number of sent messages for non blocking producer

### DIFF
--- a/java/kafka/hello-world-producer/src/main/java/KafkaProducerExample.java
+++ b/java/kafka/hello-world-producer/src/main/java/KafkaProducerExample.java
@@ -7,7 +7,6 @@ import io.jaegertracing.Configuration;
 import io.opentracing.Tracer;
 import io.opentracing.contrib.kafka.TracingProducerInterceptor;
 import io.opentracing.util.GlobalTracer;
-import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -20,10 +19,8 @@ import org.apache.logging.log4j.LogManager;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.StringTokenizer;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class KafkaProducerExample {

--- a/java/kafka/hello-world-producer/src/main/java/KafkaProducerExample.java
+++ b/java/kafka/hello-world-producer/src/main/java/KafkaProducerExample.java
@@ -61,10 +61,14 @@ public class KafkaProducerExample {
             if(blockProducer) {
                 try {
                     recordMetadataFuture.get();
+                    // Increment number of sent messages only if ack is received by producer
                     numSent.incrementAndGet();
                 } catch (ExecutionException e) {
                     log.warn("Message {} wasn't sent properly!", i);
                 }
+            } else {
+                // Increment number of sent messages for non blocking producer
+                numSent.incrementAndGet();
             }
             Thread.sleep(config.getDelay());
         }


### PR DESCRIPTION
This PR fixes return code for non-blocking example producer. Without this change, producer always exit with 1, because I forget to increment `numSet` in non-blocking part. 