### PR TITLE
Move to Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: java
 jdk:
-- openjdk8
+- openjdk11
 services:
 - docker
 script:

--- a/http/vertx/java-http-vertx-consumer/Dockerfile
+++ b/http/vertx/java-http-vertx-consumer/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-RUN yum -y install java-1.8.0-openjdk-headless openssl && yum -y clean all
+RUN yum -y update && yum -y install java-11-openjdk-headless openssl && yum -y clean all
 
 # Set JAVA_HOME env var
 ENV JAVA_HOME /usr/lib/jvm/java

--- a/http/vertx/java-http-vertx-producer/Dockerfile
+++ b/http/vertx/java-http-vertx-producer/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-RUN yum -y install java-1.8.0-openjdk-headless openssl && yum -y clean all
+RUN yum -y update && yum -y install java-11-openjdk-headless openssl && yum -y clean all
 
 # Set JAVA_HOME env var
 ENV JAVA_HOME /usr/lib/jvm/java

--- a/http/vertx/pom.xml
+++ b/http/vertx/pom.xml
@@ -12,8 +12,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <vertx.version>3.7.1</vertx.version>
         <slf4j-simple.version>1.6.2</slf4j-simple.version>

--- a/java/kafka/consumer/Dockerfile
+++ b/java/kafka/consumer/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-RUN yum -y install java-1.8.0-openjdk-headless openssl && yum -y clean all
+RUN yum -y update && yum -y install java-11-openjdk-headless openssl && yum -y clean all
 
 # Set JAVA_HOME env var
 ENV JAVA_HOME /usr/lib/jvm/java

--- a/java/kafka/pom.xml
+++ b/java/kafka/pom.xml
@@ -14,14 +14,14 @@
     <packaging>pom</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <log4j.version>2.13.3</log4j.version>
         <slf4j-simple.version>1.6.2</slf4j-simple.version>
         <kafka.version>2.6.0</kafka.version>
         <opentracing-kafka.version>0.1.11</opentracing-kafka.version>
         <jaeger.version>1.1.0</jaeger.version>
-        <strimzi-oauth-callback.version>0.6.0</strimzi-oauth-callback.version>
+        <strimzi-oauth-callback.version>0.6.1</strimzi-oauth-callback.version>
     </properties>
 
     <dependencyManagement>

--- a/java/kafka/producer/Dockerfile
+++ b/java/kafka/producer/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-RUN yum -y install java-1.8.0-openjdk-headless openssl && yum -y clean all
+RUN yum -y update && yum -y install java-11-openjdk-headless openssl && yum -y clean all
 
 # Set JAVA_HOME env var
 ENV JAVA_HOME /usr/lib/jvm/java

--- a/java/kafka/streams/Dockerfile
+++ b/java/kafka/streams/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-RUN yum -y install java-1.8.0-openjdk-headless openssl && yum -y clean all
+RUN yum -y update && yum -y install java-11-openjdk-headless openssl && yum -y clean all
 
 # Set JAVA_HOME env var
 ENV JAVA_HOME /usr/lib/jvm/java

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -56,6 +56,6 @@ fi
 JAVA_OPTS="${JAVA_OPTS} -Dvertx.cacheDirBase=/tmp -Djava.security.egd=file:/dev/./urandom"
 
 # Enable GC logging for memory tracking
-JAVA_OPTS="${JAVA_OPTS} -XX:NativeMemoryTracking=summary -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps"
+JAVA_OPTS="${JAVA_OPTS} -Xlog:gc*:stdout:time -XX:NativeMemoryTracking=summary"
 
 exec java $JAVA_OPTS -jar $JAR "$@"


### PR DESCRIPTION
Since operators moved to Java 11, it would make sense to move the examples as well. That is what is implemented in this PR:
* Move language levels to Java 11
* Move Docker images to Java 11
* Move Travis to Java 11

In addition, it also:
* Updates the base docker image before using it
* Updates the OAuth dependency from 0.6.0 to 0.6.1