### PR TITLE
Consumer prints number of received messages

### DIFF
--- a/java/kafka/consumer/src/main/java/KafkaConsumerExample.java
+++ b/java/kafka/consumer/src/main/java/KafkaConsumerExample.java
@@ -60,5 +60,6 @@ public class KafkaConsumerExample {
                 consumer.commitSync();
             }
         }
+        log.info("Received {} messages", receivedMsgs);
     }
 }


### PR DESCRIPTION
Signed-off-by: Michal Tóth <mtoth@redhat.com>

```
2021-02-24 12:37:17 INFO  KafkaConsumerExample:47 - Received message:
2021-02-24 12:37:17 INFO  KafkaConsumerExample:48 - 	partition: 0
2021-02-24 12:37:17 INFO  KafkaConsumerExample:49 - 	offset: 498
2021-02-24 12:37:17 INFO  KafkaConsumerExample:50 - 	value: "Hello world - 98"
2021-02-24 12:37:17 INFO  KafkaConsumerExample:52 - 	headers:
2021-02-24 12:37:17 INFO  KafkaConsumerExample:47 - Received message:
2021-02-24 12:37:17 INFO  KafkaConsumerExample:48 - 	partition: 0
2021-02-24 12:37:17 INFO  KafkaConsumerExample:49 - 	offset: 499
2021-02-24 12:37:17 INFO  KafkaConsumerExample:50 - 	value: "Hello world - 99"
2021-02-24 12:37:17 INFO  KafkaConsumerExample:52 - 	headers:
2021-02-24 12:37:17 INFO  KafkaConsumerExample:63 - Received 500 messages
[2021-02-24T12:37:17.446+0000] Heap
[2021-02-24T12:37:17.446+0000]  def new generation   total 72512K, used 37351K [0x0000000715600000, 0x000000071a4a0000, 0x0000000763950000)
[2021-02-24T12:37:17.446+0000]   eden space 64512K,  48% used [0x0000000715600000, 0x000000071749a350, 0x0000000719500000)
```