### PR TITLE
Parse additional config at the end of props setup to allow rewrite configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,12 @@ Producer
 * `USER_CRT` - the user's certificate
 * `USER_KEY` - the user's private key
 * `LOG_LEVEL` - logging level  
-* `PRODUCER_ACKS` = acknowledgement level
-* `HEADERS` = custom headers list separated by commas of `key1=value1, key2=value2`
-* `ADDITIONAL_CONFIG` = additional configuration for a producer application. The form is `key=value` records separated by new line character
-* `BLOCKING_PRODUCER` = if it's set, the producer will block another message until ack will be received
-* `MESSAGES_PER_TRANSACTION` = how many messages will be part of one transaction. Transaction config could be set via `ADDITIONAL_CONFIG` variable. Default is 10.
+* `PRODUCER_ACKS` - acknowledgement level
+* `HEADERS` - custom headers list separated by commas of `key1=value1, key2=value2`
+* `ADDITIONAL_CONFIG` - additional configuration for a producer application. The form is `key=value` records separated by new line character
+* `BLOCKING_PRODUCER` - if it's set, the producer will block another message until ack will be received
+* `MESSAGES_PER_TRANSACTION` - how many messages will be part of one transaction. Transaction config could be set via `ADDITIONAL_CONFIG` variable. Default is 10.
+* `SASL_CALLBACK_CLASS` - sets class for `sasl.login.callback.handler.class`; by default it uses `io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler` if possible
 
 Consumer  
 * `BOOTSTRAP_SERVERS` - comma-separated host and port pairs that is a list of Kafka broker addresses. The form of pair is `host:port`, e.g. `my-cluster-kafka-bootstrap:9092` 
@@ -78,7 +79,8 @@ Consumer
 * `USER_CRT` - the user's certificate
 * `USER_KEY` - the user's private key
 * `LOG_LEVEL` - logging level  
-* `ADDITIONAL_CONFIG` = additional configuration for a consumer application. The form is `key=value` records separated by new line character
+* `ADDITIONAL_CONFIG` - additional configuration for a consumer application. The form is `key=value` records separated by new line character
+* `SASL_CALLBACK_CLASS` - sets class for `sasl.login.callback.handler.class`; by default it uses `io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler` if possible
 
 Streams  
 * `BOOTSTRAP_SERVERS` - comma-separated host and port pairs that is a list of Kafka broker addresses. The form of pair is `host:port`, e.g. `my-cluster-kafka-bootstrap:9092`
@@ -90,7 +92,8 @@ Streams
 * `USER_CRT` - the user's certificate
 * `USER_KEY` - the user's private key
 * `LOG_LEVEL` - logging level
-* `ADDITIONAL_CONFIG` = additional configuration for a streams application. The form is `key=value` records separated by new line character
+* `ADDITIONAL_CONFIG` - additional configuration for a streams application. The form is `key=value` records separated by new line character
+* `SASL_CALLBACK_CLASS` - sets class for `sasl.login.callback.handler.class`; by default it uses `io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler` if possible
 
 ### Tracing
 

--- a/java/kafka/consumer/src/main/java/KafkaConsumerConfig.java
+++ b/java/kafka/consumer/src/main/java/KafkaConsumerConfig.java
@@ -85,20 +85,6 @@ public class KafkaConsumerConfig {
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
 
-        if (!config.getAdditionalConfig().isEmpty()) {
-            StringTokenizer tok = new StringTokenizer(config.getAdditionalConfig(), ", \t\n\r");
-            while (tok.hasMoreTokens()) {
-                String record = tok.nextToken();
-                int endIndex = record.indexOf('=');
-                if (endIndex == -1) {
-                    throw new RuntimeException("Failed to parse Map from String");
-                }
-                String key = record.substring(0, endIndex);
-                String value = record.substring(endIndex + 1);
-                props.put(key.trim(), value.trim());
-            }
-        }
-
         if (config.getTrustStorePassword() != null && config.getTrustStorePath() != null)   {
             log.info("Configuring truststore");
             props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
@@ -122,6 +108,20 @@ public class KafkaConsumerConfig {
             props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL".equals(props.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)) ? "SASL_SSL" : "SASL_PLAINTEXT");
             props.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
             props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
+        }
+
+        if (!config.getAdditionalConfig().isEmpty()) {
+            StringTokenizer tok = new StringTokenizer(config.getAdditionalConfig(), System.lineSeparator());
+            while (tok.hasMoreTokens()) {
+                String record = tok.nextToken();
+                int endIndex = record.indexOf('=');
+                if (endIndex == -1) {
+                    throw new RuntimeException("Failed to parse Map from String");
+                }
+                String key = record.substring(0, endIndex);
+                String value = record.substring(endIndex + 1);
+                props.put(key.trim(), value.trim());
+            }
         }
 
         return props;

--- a/java/kafka/consumer/src/main/java/KafkaConsumerConfig.java
+++ b/java/kafka/consumer/src/main/java/KafkaConsumerConfig.java
@@ -74,7 +74,7 @@ public class KafkaConsumerConfig {
         String oauthRefreshToken = System.getenv("OAUTH_REFRESH_TOKEN");
         String oauthTokenEndpointUri = System.getenv("OAUTH_TOKEN_ENDPOINT_URI");
         String additionalConfig = System.getenv().getOrDefault("ADDITIONAL_CONFIG", "");
-        String saslLoginCallbackClass = System.getenv("SASL_CALLBACK_CLASS") == null ? null : System.getenv().getOrDefault("SASL_CALLBACK_CLASS", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
+        String saslLoginCallbackClass = System.getenv().getOrDefault("SASL_CALLBACK_CLASS", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
 
         return new KafkaConsumerConfig(bootstrapServers, topic, groupId, clientRack, messageCount, trustStorePassword, trustStorePath,
                 keyStorePassword, keyStorePath, oauthClientId, oauthClientSecret, oauthAccessToken, oauthRefreshToken, oauthTokenEndpointUri,
@@ -120,7 +120,7 @@ public class KafkaConsumerConfig {
                 }
                 String key = record.substring(0, endIndex);
                 String value = record.substring(endIndex + 1);
-//                additionalProps.put(key.trim(), value.trim());
+                additionalProps.put(key.trim(), value.trim());
             }
         }
 
@@ -131,8 +131,7 @@ public class KafkaConsumerConfig {
             props.put(SaslConfigs.SASL_JAAS_CONFIG, "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;");
             props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL".equals(props.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)) ? "SASL_SSL" : "SASL_PLAINTEXT");
             props.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
-            if (config.saslLoginCallbackClass != null ||
-                    (additionalProps.contains(SaslConfigs.SASL_MECHANISM) && !additionalProps.getProperty(SaslConfigs.SASL_MECHANISM).equals("PLAIN"))) {
+            if (!(additionalProps.containsKey(SaslConfigs.SASL_MECHANISM) && additionalProps.getProperty(SaslConfigs.SASL_MECHANISM).equals("PLAIN"))) {
                 props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, config.saslLoginCallbackClass);
             }
         }

--- a/java/kafka/pom.xml
+++ b/java/kafka/pom.xml
@@ -21,7 +21,7 @@
         <kafka.version>2.7.0</kafka.version>
         <opentracing-kafka.version>0.1.11</opentracing-kafka.version>
         <jaeger.version>1.1.0</jaeger.version>
-        <strimzi-oauth-callback.version>0.6.1</strimzi-oauth-callback.version>
+        <strimzi-oauth-callback.version>0.7.1</strimzi-oauth-callback.version>
     </properties>
 
     <dependencyManagement>

--- a/java/kafka/producer/src/main/java/KafkaProducerConfig.java
+++ b/java/kafka/producer/src/main/java/KafkaProducerConfig.java
@@ -79,7 +79,7 @@ public class KafkaProducerConfig {
         String acks = System.getenv().getOrDefault("PRODUCER_ACKS", "1");
         String headers = System.getenv("HEADERS");
         String additionalConfig = System.getenv().getOrDefault("ADDITIONAL_CONFIG", "");
-        String saslLoginCallbackClass = System.getenv("SASL_CALLBACK_CLASS") == null ? null : System.getenv().getOrDefault("SASL_CALLBACK_CLASS", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
+        String saslLoginCallbackClass = System.getenv().getOrDefault("SASL_CALLBACK_CLASS", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
 
         return new KafkaProducerConfig(bootstrapServers, topic, delay, messageCount, message, trustStorePassword, trustStorePath,
                 keyStorePassword, keyStorePath, oauthClientId, oauthClientSecret, oauthAccessToken, oauthRefreshToken,
@@ -131,8 +131,7 @@ public class KafkaProducerConfig {
             props.put(SaslConfigs.SASL_JAAS_CONFIG, "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;");
             props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL".equals(props.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)) ? "SASL_SSL" : "SASL_PLAINTEXT");
             props.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
-            if (config.saslLoginCallbackClass != null ||
-                    (additionalProps.contains(SaslConfigs.SASL_MECHANISM) && !additionalProps.getProperty(SaslConfigs.SASL_MECHANISM).equals("PLAIN"))) {
+            if (!(additionalProps.containsKey(SaslConfigs.SASL_MECHANISM) && additionalProps.getProperty(SaslConfigs.SASL_MECHANISM).equals("PLAIN"))) {
                 props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, config.saslLoginCallbackClass);
             }
         }

--- a/java/kafka/producer/src/main/java/KafkaProducerConfig.java
+++ b/java/kafka/producer/src/main/java/KafkaProducerConfig.java
@@ -85,20 +85,6 @@ public class KafkaProducerConfig {
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
 
-        if (!config.getAdditionalConfig().isEmpty()) {
-            StringTokenizer tok = new StringTokenizer(config.getAdditionalConfig(), ", \t\n\r");
-            while (tok.hasMoreTokens()) {
-                String record = tok.nextToken();
-                int endIndex = record.indexOf('=');
-                if (endIndex == -1) {
-                    throw new RuntimeException("Failed to parse Map from String");
-                }
-                String key = record.substring(0, endIndex);
-                String value = record.substring(endIndex + 1);
-                props.put(key.trim(), value.trim());
-            }
-        }
-
         if (config.getTrustStorePassword() != null && config.getTrustStorePath() != null)   {
             log.info("Configuring truststore");
             props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
@@ -122,6 +108,20 @@ public class KafkaProducerConfig {
             props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL".equals(props.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)) ? "SASL_SSL" : "SASL_PLAINTEXT");
             props.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
             props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
+        }
+
+        if (!config.getAdditionalConfig().isEmpty()) {
+            StringTokenizer tok = new StringTokenizer(config.getAdditionalConfig(), System.lineSeparator());
+            while (tok.hasMoreTokens()) {
+                String record = tok.nextToken();
+                int endIndex = record.indexOf('=');
+                if (endIndex == -1) {
+                    throw new RuntimeException("Failed to parse Map from String");
+                }
+                String key = record.substring(0, endIndex);
+                String value = record.substring(endIndex + 1);
+                props.put(key.trim(), value.trim());
+            }
         }
 
         return props;

--- a/java/kafka/producer/src/main/java/KafkaProducerConfig.java
+++ b/java/kafka/producer/src/main/java/KafkaProducerConfig.java
@@ -35,8 +35,12 @@ public class KafkaProducerConfig {
     private final String oauthRefreshToken;
     private final String oauthTokenEndpointUri;
     private final String additionalConfig;
+    private final String saslLoginCallbackClass;
 
-    public KafkaProducerConfig(String bootstrapServers, String topic, int delay, Long messageCount, String message, String trustStorePassword, String trustStorePath, String keyStorePassword, String keyStorePath, String oauthClientId, String oauthClientSecret, String oauthAccessToken, String oauthRefreshToken, String oauthTokenEndpointUri, String acks, String additionalConfig, String headers) {
+    public KafkaProducerConfig(String bootstrapServers, String topic, int delay, Long messageCount, String message,
+                               String trustStorePassword, String trustStorePath, String keyStorePassword, String keyStorePath,
+                               String oauthClientId, String oauthClientSecret, String oauthAccessToken, String oauthRefreshToken,
+                               String oauthTokenEndpointUri, String acks, String additionalConfig, String headers, String saslLoginCallbackClass) {
         this.bootstrapServers = bootstrapServers;
         this.topic = topic;
         this.delay = delay;
@@ -54,18 +58,19 @@ public class KafkaProducerConfig {
         this.acks = acks;
         this.headers = headers;
         this.additionalConfig = additionalConfig;
+        this.saslLoginCallbackClass = saslLoginCallbackClass;
     }
 
     public static KafkaProducerConfig fromEnv() {
         String bootstrapServers = System.getenv("BOOTSTRAP_SERVERS");
         String topic = System.getenv("TOPIC");
-        int delay = Integer.valueOf(System.getenv("DELAY_MS"));
+        int delay = Integer.parseInt(System.getenv("DELAY_MS"));
         Long messageCount = System.getenv("MESSAGE_COUNT") == null ? DEFAULT_MESSAGES_COUNT : Long.valueOf(System.getenv("MESSAGE_COUNT"));
         String message = System.getenv("MESSAGE") == null ? DEFAULT_MESSAGE : System.getenv("MESSAGE");
-        String trustStorePassword = System.getenv("TRUSTSTORE_PASSWORD") == null ? null : System.getenv("TRUSTSTORE_PASSWORD");
-        String trustStorePath = System.getenv("TRUSTSTORE_PATH") == null ? null : System.getenv("TRUSTSTORE_PATH");
-        String keyStorePassword = System.getenv("KEYSTORE_PASSWORD") == null ? null : System.getenv("KEYSTORE_PASSWORD");
-        String keyStorePath = System.getenv("KEYSTORE_PATH") == null ? null : System.getenv("KEYSTORE_PATH");
+        String trustStorePassword = System.getenv("TRUSTSTORE_PASSWORD");
+        String trustStorePath = System.getenv("TRUSTSTORE_PATH");
+        String keyStorePassword = System.getenv("KEYSTORE_PASSWORD");
+        String keyStorePath = System.getenv("KEYSTORE_PATH");
         String oauthClientId = System.getenv("OAUTH_CLIENT_ID");
         String oauthClientSecret = System.getenv("OAUTH_CLIENT_SECRET");
         String oauthAccessToken = System.getenv("OAUTH_ACCESS_TOKEN");
@@ -74,8 +79,11 @@ public class KafkaProducerConfig {
         String acks = System.getenv().getOrDefault("PRODUCER_ACKS", "1");
         String headers = System.getenv("HEADERS");
         String additionalConfig = System.getenv().getOrDefault("ADDITIONAL_CONFIG", "");
+        String saslLoginCallbackClass = System.getenv("SASL_CALLBACK_CLASS") == null ? null : System.getenv().getOrDefault("SASL_CALLBACK_CLASS", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
 
-        return new KafkaProducerConfig(bootstrapServers, topic, delay, messageCount, message, trustStorePassword, trustStorePath, keyStorePassword, keyStorePath, oauthClientId, oauthClientSecret, oauthAccessToken, oauthRefreshToken, oauthTokenEndpointUri, acks, additionalConfig, headers);
+        return new KafkaProducerConfig(bootstrapServers, topic, delay, messageCount, message, trustStorePassword, trustStorePath,
+                keyStorePassword, keyStorePath, oauthClientId, oauthClientSecret, oauthAccessToken, oauthRefreshToken,
+                oauthTokenEndpointUri, acks, additionalConfig, headers, saslLoginCallbackClass);
     }
 
     public static Properties createProperties(KafkaProducerConfig config) {
@@ -101,15 +109,7 @@ public class KafkaProducerConfig {
             props.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, config.getKeyStorePath());
         }
 
-        if ((config.getOauthAccessToken() != null)
-                || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthRefreshToken() != null)
-                || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthClientSecret() != null))    {
-            props.put(SaslConfigs.SASL_JAAS_CONFIG, "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;");
-            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL".equals(props.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)) ? "SASL_SSL" : "SASL_PLAINTEXT");
-            props.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
-            props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
-        }
-
+        Properties additionalProps = new Properties();
         if (!config.getAdditionalConfig().isEmpty()) {
             StringTokenizer tok = new StringTokenizer(config.getAdditionalConfig(), System.lineSeparator());
             while (tok.hasMoreTokens()) {
@@ -120,9 +120,25 @@ public class KafkaProducerConfig {
                 }
                 String key = record.substring(0, endIndex);
                 String value = record.substring(endIndex + 1);
-                props.put(key.trim(), value.trim());
+                additionalProps.put(key.trim(), value.trim());
             }
         }
+
+        if ((config.getOauthAccessToken() != null)
+                || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthRefreshToken() != null)
+                || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthClientSecret() != null))    {
+            log.info("Configuring OAuth");
+            props.put(SaslConfigs.SASL_JAAS_CONFIG, "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;");
+            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL".equals(props.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)) ? "SASL_SSL" : "SASL_PLAINTEXT");
+            props.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
+            if (config.saslLoginCallbackClass != null ||
+                    (additionalProps.contains(SaslConfigs.SASL_MECHANISM) && !additionalProps.getProperty(SaslConfigs.SASL_MECHANISM).equals("PLAIN"))) {
+                props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, config.saslLoginCallbackClass);
+            }
+        }
+
+        // override properties with defined additional properties
+        props.putAll(additionalProps);
 
         return props;
     }

--- a/java/kafka/streams/src/main/java/KafkaStreamsConfig.java
+++ b/java/kafka/streams/src/main/java/KafkaStreamsConfig.java
@@ -75,7 +75,7 @@ public class KafkaStreamsConfig {
         String oauthRefreshToken = System.getenv("OAUTH_REFRESH_TOKEN");
         String oauthTokenEndpointUri = System.getenv("OAUTH_TOKEN_ENDPOINT_URI");
         String additionalConfig = System.getenv().getOrDefault("ADDITIONAL_CONFIG", "");
-        String saslLoginCallbackClass = System.getenv("SASL_CALLBACK_CLASS") == null ? null : System.getenv().getOrDefault("SASL_CALLBACK_CLASS", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
+        String saslLoginCallbackClass = System.getenv().getOrDefault("SASL_CALLBACK_CLASS", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
 
         return new KafkaStreamsConfig(bootstrapServers, applicationId, sourceTopic, targetTopic, commitIntervalMs,
                 trustStorePassword, trustStorePath, keyStorePassword, keyStorePath, oauthClientId, oauthClientSecret,
@@ -129,8 +129,7 @@ public class KafkaStreamsConfig {
             props.put(SaslConfigs.SASL_JAAS_CONFIG, "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;");
             props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL".equals(props.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)) ? "SASL_SSL" : "SASL_PLAINTEXT");
             props.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
-            if (config.saslLoginCallbackClass != null ||
-                    (additionalProps.contains(SaslConfigs.SASL_MECHANISM) && !additionalProps.getProperty(SaslConfigs.SASL_MECHANISM).equals("PLAIN"))) {
+            if (!(additionalProps.containsKey(SaslConfigs.SASL_MECHANISM) && additionalProps.getProperty(SaslConfigs.SASL_MECHANISM).equals("PLAIN"))) {
                 props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, config.saslLoginCallbackClass);
             }
         }

--- a/java/kafka/streams/src/main/java/KafkaStreamsConfig.java
+++ b/java/kafka/streams/src/main/java/KafkaStreamsConfig.java
@@ -82,27 +82,6 @@ public class KafkaStreamsConfig {
         props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
 
-        if (!config.getAdditionalConfig().isEmpty()) {
-            for (String configItem : config.getAdditionalConfig().split("\n")) {
-                String[] configuration = configItem.split("=");
-                props.put(configuration[0], configuration[1]);
-            }
-        }
-
-        if (!config.getAdditionalConfig().isEmpty()) {
-            StringTokenizer tok = new StringTokenizer(config.getAdditionalConfig(), ", \t\n\r");
-            while (tok.hasMoreTokens()) {
-                String record = tok.nextToken();
-                int endIndex = record.indexOf('=');
-                if (endIndex == -1) {
-                    throw new RuntimeException("Failed to parse Map from String");
-                }
-                String key = record.substring(0, endIndex);
-                String value = record.substring(endIndex + 1);
-                props.put(key.trim(), value.trim());
-            }
-        }
-
         if (config.getTrustStorePassword() != null && config.getTrustStorePath() != null)   {
             log.info("Configuring truststore");
             props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
@@ -127,6 +106,21 @@ public class KafkaStreamsConfig {
             props.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
             props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
         }
+
+        if (!config.getAdditionalConfig().isEmpty()) {
+            StringTokenizer tok = new StringTokenizer(config.getAdditionalConfig(), System.lineSeparator());
+            while (tok.hasMoreTokens()) {
+                String record = tok.nextToken();
+                int endIndex = record.indexOf('=');
+                if (endIndex == -1) {
+                    throw new RuntimeException("Failed to parse Map from String");
+                }
+                String key = record.substring(0, endIndex);
+                String value = record.substring(endIndex + 1);
+                props.put(key.trim(), value.trim());
+            }
+        }
+
 
         return props;
     }

--- a/java/kafka/streams/src/main/java/KafkaStreamsConfig.java
+++ b/java/kafka/streams/src/main/java/KafkaStreamsConfig.java
@@ -34,8 +34,13 @@ public class KafkaStreamsConfig {
     private final String oauthRefreshToken;
     private final String oauthTokenEndpointUri;
     private final String additionalConfig;
+    private final String saslLoginCallbackClass;
 
-    public KafkaStreamsConfig(String bootstrapServers, String applicationId, String sourceTopic, String targetTopic, int commitIntervalMs, String trustStorePassword, String trustStorePath, String keyStorePassword, String keyStorePath, String oauthClientId, String oauthClientSecret, String oauthAccessToken, String oauthRefreshToken, String oauthTokenEndpointUri, String additionalConfig) {
+
+    public KafkaStreamsConfig(String bootstrapServers, String applicationId, String sourceTopic, String targetTopic,
+                              int commitIntervalMs, String trustStorePassword, String trustStorePath, String keyStorePassword, String keyStorePath,
+                              String oauthClientId, String oauthClientSecret, String oauthAccessToken, String oauthRefreshToken,
+                              String oauthTokenEndpointUri, String additionalConfig, String saslLoginCallbackClass) {
         this.bootstrapServers = bootstrapServers;
         this.applicationId = applicationId;
         this.sourceTopic = sourceTopic;
@@ -51,6 +56,7 @@ public class KafkaStreamsConfig {
         this.oauthRefreshToken = oauthRefreshToken;
         this.oauthTokenEndpointUri = oauthTokenEndpointUri;
         this.additionalConfig = additionalConfig;
+        this.saslLoginCallbackClass = saslLoginCallbackClass;
     }
 
     public static KafkaStreamsConfig fromEnv() {
@@ -58,19 +64,22 @@ public class KafkaStreamsConfig {
         String sourceTopic = System.getenv("SOURCE_TOPIC");
         String targetTopic = System.getenv("TARGET_TOPIC");
         String applicationId = System.getenv("APPLICATION_ID");
-        int commitIntervalMs = System.getenv("COMMIT_INTERVAL_MS") == null ? DEFAULT_COMMIT_INTERVAL_MS : Integer.valueOf(System.getenv("COMMIT_INTERVAL_MS"));
-        String trustStorePassword = System.getenv("TRUSTSTORE_PASSWORD") == null ? null : System.getenv("TRUSTSTORE_PASSWORD");
-        String trustStorePath = System.getenv("TRUSTSTORE_PATH") == null ? null : System.getenv("TRUSTSTORE_PATH");
-        String keyStorePassword = System.getenv("KEYSTORE_PASSWORD") == null ? null : System.getenv("KEYSTORE_PASSWORD");
-        String keyStorePath = System.getenv("KEYSTORE_PATH") == null ? null : System.getenv("KEYSTORE_PATH");
+        int commitIntervalMs = System.getenv("COMMIT_INTERVAL_MS") == null ? DEFAULT_COMMIT_INTERVAL_MS : Integer.parseInt(System.getenv("COMMIT_INTERVAL_MS"));
+        String trustStorePassword = System.getenv("TRUSTSTORE_PASSWORD");
+        String trustStorePath = System.getenv("TRUSTSTORE_PATH");
+        String keyStorePassword = System.getenv("KEYSTORE_PASSWORD");
+        String keyStorePath = System.getenv("KEYSTORE_PATH");
         String oauthClientId = System.getenv("OAUTH_CLIENT_ID");
         String oauthClientSecret = System.getenv("OAUTH_CLIENT_SECRET");
         String oauthAccessToken = System.getenv("OAUTH_ACCESS_TOKEN");
         String oauthRefreshToken = System.getenv("OAUTH_REFRESH_TOKEN");
         String oauthTokenEndpointUri = System.getenv("OAUTH_TOKEN_ENDPOINT_URI");
         String additionalConfig = System.getenv().getOrDefault("ADDITIONAL_CONFIG", "");
+        String saslLoginCallbackClass = System.getenv("SASL_CALLBACK_CLASS") == null ? null : System.getenv().getOrDefault("SASL_CALLBACK_CLASS", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
 
-        return new KafkaStreamsConfig(bootstrapServers, applicationId, sourceTopic, targetTopic, commitIntervalMs, trustStorePassword, trustStorePath, keyStorePassword, keyStorePath, oauthClientId, oauthClientSecret, oauthAccessToken, oauthRefreshToken, oauthTokenEndpointUri, additionalConfig);
+        return new KafkaStreamsConfig(bootstrapServers, applicationId, sourceTopic, targetTopic, commitIntervalMs,
+                trustStorePassword, trustStorePath, keyStorePassword, keyStorePath, oauthClientId, oauthClientSecret,
+                oauthAccessToken, oauthRefreshToken, oauthTokenEndpointUri, additionalConfig, saslLoginCallbackClass);
     }
 
     public static Properties createProperties(KafkaStreamsConfig config) {
@@ -98,15 +107,7 @@ public class KafkaStreamsConfig {
             props.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, config.getKeyStorePath());
         }
 
-        if ((config.getOauthAccessToken() != null)
-                || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthRefreshToken() != null)
-                || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthClientSecret() != null))    {
-            props.put(SaslConfigs.SASL_JAAS_CONFIG, "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;");
-            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL".equals(props.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)) ? "SASL_SSL" : "SASL_PLAINTEXT");
-            props.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
-            props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
-        }
-
+        Properties additionalProps = new Properties();
         if (!config.getAdditionalConfig().isEmpty()) {
             StringTokenizer tok = new StringTokenizer(config.getAdditionalConfig(), System.lineSeparator());
             while (tok.hasMoreTokens()) {
@@ -117,10 +118,25 @@ public class KafkaStreamsConfig {
                 }
                 String key = record.substring(0, endIndex);
                 String value = record.substring(endIndex + 1);
-                props.put(key.trim(), value.trim());
+                additionalProps.put(key.trim(), value.trim());
             }
         }
 
+        if ((config.getOauthAccessToken() != null)
+                || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthRefreshToken() != null)
+                || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthClientSecret() != null))    {
+            log.info("Configuring OAuth");
+            props.put(SaslConfigs.SASL_JAAS_CONFIG, "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;");
+            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL".equals(props.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)) ? "SASL_SSL" : "SASL_PLAINTEXT");
+            props.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
+            if (config.saslLoginCallbackClass != null ||
+                    (additionalProps.contains(SaslConfigs.SASL_MECHANISM) && !additionalProps.getProperty(SaslConfigs.SASL_MECHANISM).equals("PLAIN"))) {
+                props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, config.saslLoginCallbackClass);
+            }
+        }
+
+        // override properties with defined additional properties
+        props.putAll(additionalProps);
 
         return props;
     }


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

This PR allows us to rewrite all configurations just only via `ADDITIONAL_CONFIG` value. This change will be very useful for integrating clients-examples into strimzi system tests. without this, we will need some additional env wars to setup scram-sha for example, etc.

Tests: tried few things manually and run some tests from the operator repo and everything looks good.