### PR TITLE
Parse additional config at the end of props setup to allow rewrite configurations 

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Producer
 * `HEADERS` - custom headers list separated by commas of `key1=value1, key2=value2`
 * `BLOCKING_PRODUCER` - if it's set, the producer will block another message until ack will be received
 * `MESSAGES_PER_TRANSACTION` - how many messages will be part of one transaction. Transaction config could be set via `ADDITIONAL_CONFIG` variable. Default is 10.
-* `SASL_CALLBACK_CLASS` - sets class for `sasl.login.callback.handler.class`; by default it uses `io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler` if possible
 * `ADDITIONAL_CONFIG` - additional configuration for a producer application. Notice, that you can also override any previously set variable by setting this. The form is `key=value` records separated by new line character
 
 Consumer  
@@ -79,7 +78,6 @@ Consumer
 * `USER_CRT` - the user's certificate
 * `USER_KEY` - the user's private key
 * `LOG_LEVEL` - logging level  
-* `SASL_CALLBACK_CLASS` - sets class for `sasl.login.callback.handler.class`; by default it uses `io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler` if possible
 * `ADDITIONAL_CONFIG` - additional configuration for a consumer application. Notice, that you can also override any previously set variable by setting this. The form is `key=value` records separated by new line character
 
 Streams  
@@ -92,7 +90,6 @@ Streams
 * `USER_CRT` - the user's certificate
 * `USER_KEY` - the user's private key
 * `LOG_LEVEL` - logging level
-* `SASL_CALLBACK_CLASS` - sets class for `sasl.login.callback.handler.class`; by default it uses `io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler` if possible
 * `ADDITIONAL_CONFIG` - additional configuration for a streams application. Notice, that you can also override any previously set variable by setting this. The form is `key=value` records separated by new line character.
 
 ### Tracing

--- a/README.md
+++ b/README.md
@@ -63,11 +63,12 @@ Producer
 * `USER_CRT` - the user's certificate
 * `USER_KEY` - the user's private key
 * `LOG_LEVEL` - logging level  
-* `PRODUCER_ACKS` = acknowledgement level
-* `HEADERS` = custom headers list separated by commas of `key1=value1, key2=value2`
-* `ADDITIONAL_CONFIG` = additional configuration for a producer application. The form is `key=value` records separated by new line character
-* `BLOCKING_PRODUCER` = if it's set, the producer will block another message until ack will be received
-* `MESSAGES_PER_TRANSACTION` = how many messages will be part of one transaction. Transaction config could be set via `ADDITIONAL_CONFIG` variable. Default is 10.
+* `PRODUCER_ACKS` - acknowledgement level
+* `HEADERS` - custom headers list separated by commas of `key1=value1, key2=value2`
+* `BLOCKING_PRODUCER` - if it's set, the producer will block another message until ack will be received
+* `MESSAGES_PER_TRANSACTION` - how many messages will be part of one transaction. Transaction config could be set via `ADDITIONAL_CONFIG` variable. Default is 10.
+* `SASL_CALLBACK_CLASS` - sets class for `sasl.login.callback.handler.class`; by default it uses `io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler` if possible
+* `ADDITIONAL_CONFIG` - additional configuration for a producer application. Notice, that you can also override any previously set variable by setting this. The form is `key=value` records separated by new line character
 
 Consumer  
 * `BOOTSTRAP_SERVERS` - comma-separated host and port pairs that is a list of Kafka broker addresses. The form of pair is `host:port`, e.g. `my-cluster-kafka-bootstrap:9092` 
@@ -78,7 +79,8 @@ Consumer
 * `USER_CRT` - the user's certificate
 * `USER_KEY` - the user's private key
 * `LOG_LEVEL` - logging level  
-* `ADDITIONAL_CONFIG` = additional configuration for a consumer application. The form is `key=value` records separated by new line character
+* `SASL_CALLBACK_CLASS` - sets class for `sasl.login.callback.handler.class`; by default it uses `io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler` if possible
+* `ADDITIONAL_CONFIG` - additional configuration for a consumer application. Notice, that you can also override any previously set variable by setting this. The form is `key=value` records separated by new line character
 
 Streams  
 * `BOOTSTRAP_SERVERS` - comma-separated host and port pairs that is a list of Kafka broker addresses. The form of pair is `host:port`, e.g. `my-cluster-kafka-bootstrap:9092`
@@ -90,7 +92,8 @@ Streams
 * `USER_CRT` - the user's certificate
 * `USER_KEY` - the user's private key
 * `LOG_LEVEL` - logging level
-* `ADDITIONAL_CONFIG` = additional configuration for a streams application. The form is `key=value` records separated by new line character
+* `SASL_CALLBACK_CLASS` - sets class for `sasl.login.callback.handler.class`; by default it uses `io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler` if possible
+* `ADDITIONAL_CONFIG` - additional configuration for a streams application. Notice, that you can also override any previously set variable by setting this. The form is `key=value` records separated by new line character.
 
 ### Tracing
 

--- a/java/kafka/consumer/src/main/java/KafkaConsumerConfig.java
+++ b/java/kafka/consumer/src/main/java/KafkaConsumerConfig.java
@@ -34,8 +34,12 @@ public class KafkaConsumerConfig {
     private final String oauthRefreshToken;
     private final String oauthTokenEndpointUri;
     private final String additionalConfig;
+    private final String saslLoginCallbackClass;
 
-    public KafkaConsumerConfig(String bootstrapServers, String topic, String groupId, String clientRack, Long messageCount, String trustStorePassword, String trustStorePath, String keyStorePassword, String keyStorePath, String oauthClientId, String oauthClientSecret, String oauthAccessToken, String oauthRefreshToken, String oauthTokenEndpointUri, String additionalConfig) {
+    public KafkaConsumerConfig(String bootstrapServers, String topic, String groupId, String clientRack, Long messageCount,
+                               String trustStorePassword, String trustStorePath, String keyStorePassword, String keyStorePath,
+                               String oauthClientId, String oauthClientSecret, String oauthAccessToken, String oauthRefreshToken,
+                               String oauthTokenEndpointUri, String additionalConfig, String saslLoginCallbackClass) {
         this.bootstrapServers = bootstrapServers;
         this.topic = topic;
         this.groupId = groupId;
@@ -51,26 +55,30 @@ public class KafkaConsumerConfig {
         this.oauthRefreshToken = oauthRefreshToken;
         this.oauthTokenEndpointUri = oauthTokenEndpointUri;
         this.additionalConfig = additionalConfig;
+        this.saslLoginCallbackClass = saslLoginCallbackClass;
     }
 
     public static KafkaConsumerConfig fromEnv() {
         String bootstrapServers = System.getenv("BOOTSTRAP_SERVERS");
         String topic = System.getenv("TOPIC");
         String groupId = System.getenv("GROUP_ID");
-        String clientRack = System.getenv("CLIENT_RACK") == null ? null : System.getenv("CLIENT_RACK");
+        String clientRack = System.getenv("CLIENT_RACK");
         Long messageCount = System.getenv("MESSAGE_COUNT") == null ? DEFAULT_MESSAGES_COUNT : Long.valueOf(System.getenv("MESSAGE_COUNT"));
-        String trustStorePassword = System.getenv("TRUSTSTORE_PASSWORD") == null ? null : System.getenv("TRUSTSTORE_PASSWORD");
-        String trustStorePath = System.getenv("TRUSTSTORE_PATH") == null ? null : System.getenv("TRUSTSTORE_PATH");
-        String keyStorePassword = System.getenv("KEYSTORE_PASSWORD") == null ? null : System.getenv("KEYSTORE_PASSWORD");
-        String keyStorePath = System.getenv("KEYSTORE_PATH") == null ? null : System.getenv("KEYSTORE_PATH");
+        String trustStorePassword = System.getenv("TRUSTSTORE_PASSWORD");
+        String trustStorePath = System.getenv("TRUSTSTORE_PATH");
+        String keyStorePassword = System.getenv("KEYSTORE_PASSWORD");
+        String keyStorePath = System.getenv("KEYSTORE_PATH");
         String oauthClientId = System.getenv("OAUTH_CLIENT_ID");
         String oauthClientSecret = System.getenv("OAUTH_CLIENT_SECRET");
         String oauthAccessToken = System.getenv("OAUTH_ACCESS_TOKEN");
         String oauthRefreshToken = System.getenv("OAUTH_REFRESH_TOKEN");
         String oauthTokenEndpointUri = System.getenv("OAUTH_TOKEN_ENDPOINT_URI");
         String additionalConfig = System.getenv().getOrDefault("ADDITIONAL_CONFIG", "");
+        String saslLoginCallbackClass = System.getenv().getOrDefault("SASL_CALLBACK_CLASS", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
 
-        return new KafkaConsumerConfig(bootstrapServers, topic, groupId, clientRack, messageCount, trustStorePassword, trustStorePath, keyStorePassword, keyStorePath, oauthClientId, oauthClientSecret, oauthAccessToken, oauthRefreshToken, oauthTokenEndpointUri, additionalConfig);
+        return new KafkaConsumerConfig(bootstrapServers, topic, groupId, clientRack, messageCount, trustStorePassword, trustStorePath,
+                keyStorePassword, keyStorePath, oauthClientId, oauthClientSecret, oauthAccessToken, oauthRefreshToken, oauthTokenEndpointUri,
+                additionalConfig, saslLoginCallbackClass);
     }
 
     public static Properties createProperties(KafkaConsumerConfig config) {
@@ -84,20 +92,6 @@ public class KafkaConsumerConfig {
         props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, config.getEnableAutoCommit());
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
-
-        if (!config.getAdditionalConfig().isEmpty()) {
-            StringTokenizer tok = new StringTokenizer(config.getAdditionalConfig(), ", \t\n\r");
-            while (tok.hasMoreTokens()) {
-                String record = tok.nextToken();
-                int endIndex = record.indexOf('=');
-                if (endIndex == -1) {
-                    throw new RuntimeException("Failed to parse Map from String");
-                }
-                String key = record.substring(0, endIndex);
-                String value = record.substring(endIndex + 1);
-                props.put(key.trim(), value.trim());
-            }
-        }
 
         if (config.getTrustStorePassword() != null && config.getTrustStorePath() != null)   {
             log.info("Configuring truststore");
@@ -115,14 +109,35 @@ public class KafkaConsumerConfig {
             props.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, config.getKeyStorePath());
         }
 
+        Properties additionalProps = new Properties();
+        if (!config.getAdditionalConfig().isEmpty()) {
+            StringTokenizer tok = new StringTokenizer(config.getAdditionalConfig(), System.lineSeparator());
+            while (tok.hasMoreTokens()) {
+                String record = tok.nextToken();
+                int endIndex = record.indexOf('=');
+                if (endIndex == -1) {
+                    throw new RuntimeException("Failed to parse Map from String");
+                }
+                String key = record.substring(0, endIndex);
+                String value = record.substring(endIndex + 1);
+                additionalProps.put(key.trim(), value.trim());
+            }
+        }
+
         if ((config.getOauthAccessToken() != null)
                 || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthRefreshToken() != null)
                 || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthClientSecret() != null))    {
+            log.info("Configuring OAuth");
             props.put(SaslConfigs.SASL_JAAS_CONFIG, "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;");
             props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL".equals(props.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)) ? "SASL_SSL" : "SASL_PLAINTEXT");
             props.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
-            props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
+            if (!(additionalProps.containsKey(SaslConfigs.SASL_MECHANISM) && additionalProps.getProperty(SaslConfigs.SASL_MECHANISM).equals("PLAIN"))) {
+                props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, config.saslLoginCallbackClass);
+            }
         }
+
+        // override properties with defined additional properties
+        props.putAll(additionalProps);
 
         return props;
     }

--- a/java/kafka/consumer/src/main/java/KafkaConsumerConfig.java
+++ b/java/kafka/consumer/src/main/java/KafkaConsumerConfig.java
@@ -34,12 +34,14 @@ public class KafkaConsumerConfig {
     private final String oauthRefreshToken;
     private final String oauthTokenEndpointUri;
     private final String additionalConfig;
-    private final String saslLoginCallbackClass;
+    private final String saslLoginCallbackClass = "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler";
+    ;
+
 
     public KafkaConsumerConfig(String bootstrapServers, String topic, String groupId, String clientRack, Long messageCount,
                                String trustStorePassword, String trustStorePath, String keyStorePassword, String keyStorePath,
                                String oauthClientId, String oauthClientSecret, String oauthAccessToken, String oauthRefreshToken,
-                               String oauthTokenEndpointUri, String additionalConfig, String saslLoginCallbackClass) {
+                               String oauthTokenEndpointUri, String additionalConfig) {
         this.bootstrapServers = bootstrapServers;
         this.topic = topic;
         this.groupId = groupId;
@@ -55,7 +57,7 @@ public class KafkaConsumerConfig {
         this.oauthRefreshToken = oauthRefreshToken;
         this.oauthTokenEndpointUri = oauthTokenEndpointUri;
         this.additionalConfig = additionalConfig;
-        this.saslLoginCallbackClass = saslLoginCallbackClass;
+        ;
     }
 
     public static KafkaConsumerConfig fromEnv() {
@@ -74,11 +76,10 @@ public class KafkaConsumerConfig {
         String oauthRefreshToken = System.getenv("OAUTH_REFRESH_TOKEN");
         String oauthTokenEndpointUri = System.getenv("OAUTH_TOKEN_ENDPOINT_URI");
         String additionalConfig = System.getenv().getOrDefault("ADDITIONAL_CONFIG", "");
-        String saslLoginCallbackClass = System.getenv().getOrDefault("SASL_CALLBACK_CLASS", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
 
         return new KafkaConsumerConfig(bootstrapServers, topic, groupId, clientRack, messageCount, trustStorePassword, trustStorePath,
                 keyStorePassword, keyStorePath, oauthClientId, oauthClientSecret, oauthAccessToken, oauthRefreshToken, oauthTokenEndpointUri,
-                additionalConfig, saslLoginCallbackClass);
+                additionalConfig);
     }
 
     public static Properties createProperties(KafkaConsumerConfig config) {

--- a/java/kafka/pom.xml
+++ b/java/kafka/pom.xml
@@ -21,7 +21,7 @@
         <kafka.version>2.7.0</kafka.version>
         <opentracing-kafka.version>0.1.11</opentracing-kafka.version>
         <jaeger.version>1.1.0</jaeger.version>
-        <strimzi-oauth-callback.version>0.6.1</strimzi-oauth-callback.version>
+        <strimzi-oauth-callback.version>0.7.1</strimzi-oauth-callback.version>
     </properties>
 
     <dependencyManagement>

--- a/java/kafka/producer/src/main/java/KafkaProducerConfig.java
+++ b/java/kafka/producer/src/main/java/KafkaProducerConfig.java
@@ -35,12 +35,12 @@ public class KafkaProducerConfig {
     private final String oauthRefreshToken;
     private final String oauthTokenEndpointUri;
     private final String additionalConfig;
-    private final String saslLoginCallbackClass;
+    private final String saslLoginCallbackClass = "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler";
 
     public KafkaProducerConfig(String bootstrapServers, String topic, int delay, Long messageCount, String message,
                                String trustStorePassword, String trustStorePath, String keyStorePassword, String keyStorePath,
                                String oauthClientId, String oauthClientSecret, String oauthAccessToken, String oauthRefreshToken,
-                               String oauthTokenEndpointUri, String acks, String additionalConfig, String headers, String saslLoginCallbackClass) {
+                               String oauthTokenEndpointUri, String acks, String additionalConfig, String headers) {
         this.bootstrapServers = bootstrapServers;
         this.topic = topic;
         this.delay = delay;
@@ -58,7 +58,6 @@ public class KafkaProducerConfig {
         this.acks = acks;
         this.headers = headers;
         this.additionalConfig = additionalConfig;
-        this.saslLoginCallbackClass = saslLoginCallbackClass;
     }
 
     public static KafkaProducerConfig fromEnv() {
@@ -79,11 +78,10 @@ public class KafkaProducerConfig {
         String acks = System.getenv().getOrDefault("PRODUCER_ACKS", "1");
         String headers = System.getenv("HEADERS");
         String additionalConfig = System.getenv().getOrDefault("ADDITIONAL_CONFIG", "");
-        String saslLoginCallbackClass = System.getenv().getOrDefault("SASL_CALLBACK_CLASS", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
 
         return new KafkaProducerConfig(bootstrapServers, topic, delay, messageCount, message, trustStorePassword, trustStorePath,
                 keyStorePassword, keyStorePath, oauthClientId, oauthClientSecret, oauthAccessToken, oauthRefreshToken,
-                oauthTokenEndpointUri, acks, additionalConfig, headers, saslLoginCallbackClass);
+                oauthTokenEndpointUri, acks, additionalConfig, headers);
     }
 
     public static Properties createProperties(KafkaProducerConfig config) {

--- a/java/kafka/streams/src/main/java/KafkaStreamsConfig.java
+++ b/java/kafka/streams/src/main/java/KafkaStreamsConfig.java
@@ -34,13 +34,13 @@ public class KafkaStreamsConfig {
     private final String oauthRefreshToken;
     private final String oauthTokenEndpointUri;
     private final String additionalConfig;
-    private final String saslLoginCallbackClass;
+    private final String saslLoginCallbackClass = "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler";
 
 
     public KafkaStreamsConfig(String bootstrapServers, String applicationId, String sourceTopic, String targetTopic,
                               int commitIntervalMs, String trustStorePassword, String trustStorePath, String keyStorePassword, String keyStorePath,
                               String oauthClientId, String oauthClientSecret, String oauthAccessToken, String oauthRefreshToken,
-                              String oauthTokenEndpointUri, String additionalConfig, String saslLoginCallbackClass) {
+                              String oauthTokenEndpointUri, String additionalConfig) {
         this.bootstrapServers = bootstrapServers;
         this.applicationId = applicationId;
         this.sourceTopic = sourceTopic;
@@ -56,7 +56,6 @@ public class KafkaStreamsConfig {
         this.oauthRefreshToken = oauthRefreshToken;
         this.oauthTokenEndpointUri = oauthTokenEndpointUri;
         this.additionalConfig = additionalConfig;
-        this.saslLoginCallbackClass = saslLoginCallbackClass;
     }
 
     public static KafkaStreamsConfig fromEnv() {
@@ -75,11 +74,10 @@ public class KafkaStreamsConfig {
         String oauthRefreshToken = System.getenv("OAUTH_REFRESH_TOKEN");
         String oauthTokenEndpointUri = System.getenv("OAUTH_TOKEN_ENDPOINT_URI");
         String additionalConfig = System.getenv().getOrDefault("ADDITIONAL_CONFIG", "");
-        String saslLoginCallbackClass = System.getenv().getOrDefault("SASL_CALLBACK_CLASS", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
 
         return new KafkaStreamsConfig(bootstrapServers, applicationId, sourceTopic, targetTopic, commitIntervalMs,
                 trustStorePassword, trustStorePath, keyStorePassword, keyStorePath, oauthClientId, oauthClientSecret,
-                oauthAccessToken, oauthRefreshToken, oauthTokenEndpointUri, additionalConfig, saslLoginCallbackClass);
+                oauthAccessToken, oauthRefreshToken, oauthTokenEndpointUri, additionalConfig);
     }
 
     public static Properties createProperties(KafkaStreamsConfig config) {


### PR DESCRIPTION
This is a "duplicate" from #54 - as I did not have direct access to @Frawless PR for these small requested changes. 
So I opened a new PR.

As mentioned, just for clarification, here are my changes: 

- Main goal of my changes is to get rid of sasl.login.callback.handler.class, as it was used there hardwired.
- Using this additional configuration, sasl.mechanism can be overridden as well (hardwired to OAUTHBEARER now)
- Minor updates:
> - some clean up code
> - simplify statements
> - added readme docs for this new env variable