### PR TITLE
Use UBI8 as a new base image

### DIFF
--- a/http/vertx/java-http-vertx-consumer/Dockerfile
+++ b/http/vertx/java-http-vertx-consumer/Dockerfile
@@ -1,9 +1,17 @@
-FROM centos:7
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-RUN yum -y update && yum -y install java-11-openjdk-headless openssl && yum -y clean all
+USER root
+
+RUN microdnf update \
+    && microdnf install java-11-openjdk-headless shadow-utils \
+    && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/java
+ENV JAVA_HOME /usr/lib/jvm/jre-11
+
+# Add strimzi user with UID 1001
+# The user is in the group 0 to have access to the mounted volumes and storage
+RUN useradd -r -m -u 1001 -g 0 strimzi
 
 ARG version=latest
 ENV VERSION ${version}
@@ -14,5 +22,7 @@ COPY ./src/main/resources/log4j2.properties /bin/log4j2.properties
 COPY ./scripts/ /bin
 
 ADD target/java-http-vertx-consumer.jar /
+
+USER 1001
 
 CMD ["/bin/run.sh", "/java-http-vertx-consumer.jar"]

--- a/http/vertx/java-http-vertx-producer/Dockerfile
+++ b/http/vertx/java-http-vertx-producer/Dockerfile
@@ -1,9 +1,17 @@
-FROM centos:7
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-RUN yum -y update && yum -y install java-11-openjdk-headless openssl && yum -y clean all
+USER root
+
+RUN microdnf update \
+    && microdnf install java-11-openjdk-headless shadow-utils \
+    && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/java
+ENV JAVA_HOME /usr/lib/jvm/jre-11
+
+# Add strimzi user with UID 1001
+# The user is in the group 0 to have access to the mounted volumes and storage
+RUN useradd -r -m -u 1001 -g 0 strimzi
 
 ARG version=latest
 ENV VERSION ${version}
@@ -12,5 +20,7 @@ COPY ./scripts/ /bin
 COPY ./src/main/resources/log4j2.properties /bin/log4j2.properties
 
 ADD target/java-http-vertx-producer.jar /
+
+USER 1001
 
 CMD ["/bin/run.sh", "/java-http-vertx-producer.jar"]

--- a/java/kafka/consumer/Dockerfile
+++ b/java/kafka/consumer/Dockerfile
@@ -1,9 +1,17 @@
-FROM centos:7
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-RUN yum -y update && yum -y install java-11-openjdk-headless openssl && yum -y clean all
+USER root
+
+RUN microdnf update \
+    && microdnf install java-11-openjdk-headless shadow-utils \
+    && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/java
+ENV JAVA_HOME /usr/lib/jvm/jre-11
+
+# Add strimzi user with UID 1001
+# The user is in the group 0 to have access to the mounted volumes and storage
+RUN useradd -r -m -u 1001 -g 0 strimzi
 
 ARG version=latest
 ENV VERSION ${version}
@@ -12,5 +20,7 @@ COPY ./scripts/ /bin
 COPY ./src/main/resources/log4j2.properties /bin/log4j2.properties
 
 ADD target/java-kafka-consumer-1.0-SNAPSHOT.jar /
+
+USER 1001
 
 CMD ["/bin/run.sh", "/java-kafka-consumer-1.0-SNAPSHOT.jar"]

--- a/java/kafka/producer/Dockerfile
+++ b/java/kafka/producer/Dockerfile
@@ -1,9 +1,17 @@
-FROM centos:7
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-RUN yum -y update && yum -y install java-11-openjdk-headless openssl && yum -y clean all
+USER root
+
+RUN microdnf update \
+    && microdnf install java-11-openjdk-headless shadow-utils \
+    && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/java
+ENV JAVA_HOME /usr/lib/jvm/jre-11
+
+# Add strimzi user with UID 1001
+# The user is in the group 0 to have access to the mounted volumes and storage
+RUN useradd -r -m -u 1001 -g 0 strimzi
 
 ARG version=latest
 ENV VERSION ${version}
@@ -12,5 +20,7 @@ COPY ./scripts/ /bin
 COPY ./src/main/resources/log4j2.properties /bin/log4j2.properties
 
 ADD target/java-kafka-producer-1.0-SNAPSHOT.jar /
+
+USER 1001
 
 CMD ["/bin/run.sh", "/java-kafka-producer-1.0-SNAPSHOT.jar"]

--- a/java/kafka/streams/Dockerfile
+++ b/java/kafka/streams/Dockerfile
@@ -1,9 +1,17 @@
-FROM centos:7
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-RUN yum -y update && yum -y install java-11-openjdk-headless openssl && yum -y clean all
+USER root
+
+RUN microdnf update \
+    && microdnf install java-11-openjdk-headless shadow-utils \
+    && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/java
+ENV JAVA_HOME /usr/lib/jvm/jre-11
+
+# Add strimzi user with UID 1001
+# The user is in the group 0 to have access to the mounted volumes and storage
+RUN useradd -r -m -u 1001 -g 0 strimzi
 
 ARG version=latest
 ENV VERSION ${version}
@@ -12,5 +20,7 @@ COPY ./scripts/ /bin
 COPY ./src/main/resources/log4j2.properties /bin/log4j2.properties
 
 ADD target/java-kafka-streams-1.0-SNAPSHOT.jar /
+
+USER 1001
 
 CMD ["/bin/run.sh", "/java-kafka-streams-1.0-SNAPSHOT.jar"]


### PR DESCRIPTION
This PR updates the base image used by Strimzi Client Examples to Red Hat UBI8 as proposed by [SP-23](https://github.com/strimzi/proposals/blob/main/023-using-ubi8-as-base-image.md).