### PR TITLE
Fix `toString` method in Kafka client examples configuration classes

### DIFF
--- a/java/kafka/consumer/src/main/java/KafkaConsumerConfig.java
+++ b/java/kafka/consumer/src/main/java/KafkaConsumerConfig.java
@@ -211,9 +211,9 @@ public class KafkaConsumerConfig {
             ", enableAutoCommit='" + enableAutoCommit + '\'' +
             ", clientRack='" + clientRack + '\'' +
             ", messageCount=" + messageCount +
-            ", trustStorePassword='" + sslTruststoreCertificates + '\'' +
-            ", trustStorePath='" + sslKeystoreKey + '\'' +
-            ", keyStorePassword='" + sslKeystoreCertificateChain + '\'' +
+            ", sslTruststoreCertificates='" + sslTruststoreCertificates + '\'' +
+            ", sslKeystoreKey='" + sslKeystoreKey + '\'' +
+            ", sslKeystoreCertificateChain='" + sslKeystoreCertificateChain + '\'' +
             ", oauthClientId='" + oauthClientId + '\'' +
             ", oauthClientSecret='" + oauthClientSecret + '\'' +
             ", oauthAccessToken='" + oauthAccessToken + '\'' +

--- a/java/kafka/producer/src/main/java/KafkaProducerConfig.java
+++ b/java/kafka/producer/src/main/java/KafkaProducerConfig.java
@@ -209,9 +209,9 @@ public class KafkaProducerConfig {
             ", message='" + message + '\'' +
             ", acks='" + acks + '\'' +
             ", headers='" + headers + '\'' +
-            ", trustStorePassword='" + sslTruststoreCertificates + '\'' +
-            ", trustStorePath='" + sslKeystoreKey + '\'' +
-            ", keyStorePassword='" + sslKeystoreCertificateChain + '\'' +
+            ", sslTruststoreCertificates='" + sslTruststoreCertificates + '\'' +
+            ", sslKeystoreKey='" + sslKeystoreKey + '\'' +
+            ", sslKeystoreCertificateChain='" + sslKeystoreCertificateChain + '\'' +
             ", oauthClientId='" + oauthClientId + '\'' +
             ", oauthClientSecret='" + oauthClientSecret + '\'' +
             ", oauthAccessToken='" + oauthAccessToken + '\'' +

--- a/java/kafka/streams/src/main/java/KafkaStreamsConfig.java
+++ b/java/kafka/streams/src/main/java/KafkaStreamsConfig.java
@@ -196,9 +196,9 @@ public class KafkaStreamsConfig {
             ", sourceTopic='" + sourceTopic + '\'' +
             ", targetTopic='" + targetTopic + '\'' +
             ", commitIntervalMs=" + commitIntervalMs +
-            ", trustStorePassword='" + sslTruststoreCertificates + '\'' +
-            ", trustStorePath='" + sslKeystoreKey + '\'' +
-            ", keyStorePassword='" + sslKeystoreCertificateChain + '\'' +
+            ", sslTruststoreCertificates='" + sslTruststoreCertificates + '\'' +
+            ", sslKeystoreKey='" + sslKeystoreKey + '\'' +
+            ", sslKeystoreCertificateChain='" + sslKeystoreCertificateChain + '\'' +
             ", oauthClientId='" + oauthClientId + '\'' +
             ", oauthClientSecret='" + oauthClientSecret + '\'' +
             ", oauthAccessToken='" + oauthAccessToken + '\'' +


### PR DESCRIPTION
When updating the client examples to use the PEM certificates directly, we (well, I screwed it up of course 🤦‍♂️) updated the configuration classes, but not their `toString` methods. These are now printing confusing info into the logs. This PR fixes the values.