### PR TITLE
Update the OAuth library to 0.8.0

### DIFF
--- a/java/kafka/deployment-oauth.yaml
+++ b/java/kafka/deployment-oauth.yaml
@@ -88,7 +88,9 @@ spec:
                 key: clientSecret
           - name: OAUTH_TOKEN_ENDPOINT_URI
             value: https://sso.myproject.svc:8443/auth/realms/internal/protocol/openid-connect/token
-          - name: OAUTH_CRT
+          - name: OAUTH_SSL_TRUSTSTORE_TYPE
+            value: PEM
+          - name: OAUTH_SSL_TRUSTSTORE_CERTIFICATES
             valueFrom:
               secretKeyRef:
                 name: sso-x509-https-secret
@@ -177,7 +179,9 @@ spec:
                   key: clientSecret
             - name: OAUTH_TOKEN_ENDPOINT_URI
               value: https://sso.myproject.svc:8443/auth/realms/internal/protocol/openid-connect/token
-            - name: OAUTH_CRT
+            - name: OAUTH_SSL_TRUSTSTORE_TYPE
+              value: PEM
+            - name: OAUTH_SSL_TRUSTSTORE_CERTIFICATES
               valueFrom:
                 secretKeyRef:
                   name: sso-x509-https-secret
@@ -253,7 +257,9 @@ spec:
                   key: clientSecret
             - name: OAUTH_TOKEN_ENDPOINT_URI
               value: https://sso.myproject.svc:8443/auth/realms/internal/protocol/openid-connect/token
-            - name: OAUTH_CRT
+            - name: OAUTH_SSL_TRUSTSTORE_TYPE
+              value: PEM
+            - name: OAUTH_SSL_TRUSTSTORE_CERTIFICATES
               valueFrom:
                 secretKeyRef:
                   name: sso-x509-https-secret

--- a/java/kafka/pom.xml
+++ b/java/kafka/pom.xml
@@ -18,11 +18,18 @@
         <maven.compiler.target>11</maven.compiler.target>
         <log4j.version>2.13.3</log4j.version>
         <slf4j-simple.version>1.6.2</slf4j-simple.version>
-        <kafka.version>2.7.0</kafka.version>
-        <opentracing-kafka.version>0.1.11</opentracing-kafka.version>
+        <kafka.version>2.8.0</kafka.version>
+        <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
         <jaeger.version>1.1.0</jaeger.version>
-        <strimzi-oauth-callback.version>0.7.1</strimzi-oauth-callback.version>
+        <strimzi-oauth-callback.version>0.8.0</strimzi-oauth-callback.version>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>oauth-staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1104</url>
+        </repository>
+    </repositories>
 
     <dependencyManagement>
         <dependencies>

--- a/java/kafka/pom.xml
+++ b/java/kafka/pom.xml
@@ -24,13 +24,6 @@
         <strimzi-oauth-callback.version>0.8.0</strimzi-oauth-callback.version>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>oauth-staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1104</url>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,26 +1,8 @@
 #!/bin/bash
 set +x
 
-# Parameters:
-# $1: Path to the new truststore
-# $2: Truststore password
-# $3: Public key to be imported
-# $4: Alias of the certificate
-function create_truststore {
-   keytool -keystore $1 -storepass $2 -noprompt -alias $4 -import -file $3 -storetype PKCS12
-}
-
 if [ -z "$JAVA_OPTS" ]; then
     export JAVA_OPTS="${JAVA_OPTS} -Dlog4j2.configurationFile=file:bin/log4j2.properties"
-fi
-
-if [ "$OAUTH_CRT" ];
-then
-    echo "Preparing OAuth truststore"
-    export OAUTH_SSL_TRUSTSTORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)
-    echo "$OAUTH_CRT" > /tmp/oauth.crt
-    create_truststore /tmp/oauth-truststore.p12 $OAUTH_SSL_TRUSTSTORE_PASSWORD /tmp/oauth.crt ca
-    export OAUTH_SSL_TRUSTSTORE_LOCATION=/tmp/oauth-truststore.p12
 fi
 
 # Make sure that we use /dev/urandom


### PR DESCRIPTION
This PR updates the client examples to use the Strimzi OAuth library 0.8.0. Since 0.8.0 can load certificates directly from the PEM format, it uses this new feature and removes the old certificate preparation using JKS format. It also updates some other dependencies such as Kafka clients or tracing.