### PR TITLE
Update OAuth library to 0.8.1

### DIFF
--- a/java/kafka/pom.xml
+++ b/java/kafka/pom.xml
@@ -21,7 +21,7 @@
         <kafka.version>2.8.0</kafka.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
         <jaeger.version>1.1.0</jaeger.version>
-        <strimzi-oauth-callback.version>0.8.0</strimzi-oauth-callback.version>
+        <strimzi-oauth-callback.version>0.8.1</strimzi-oauth-callback.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
This PR updates the OAuth library to 0.8.1 to address CVE-2021-27568.