### PR TITLE
further remove jaeger from StreamsExaxmple

### DIFF
--- a/java/kafka/deployment-tracing-jaeger.yaml
+++ b/java/kafka/deployment-tracing-jaeger.yaml
@@ -63,47 +63,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: java-kafka-streams
-  name: java-kafka-streams
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: java-kafka-streams
-  template:
-    metadata:
-      labels:
-        app: java-kafka-streams
-    spec:
-      containers:
-        - name: java-kafka-streams
-          image: quay.io/strimzi-examples/java-kafka-streams:latest
-          env:
-            - name: BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9092
-            - name: APPLICATION_ID
-              value: java-kafka-streams
-            - name: SOURCE_TOPIC
-              value: my-topic
-            - name: TARGET_TOPIC
-              value: my-topic-reversed
-            - name: LOG_LEVEL
-              value: "INFO"
-            - name: JAEGER_SERVICE_NAME
-              value: java-kafka-streams
-            - name: JAEGER_AGENT_HOST
-              value: my-jaeger-agent
-            - name: JAEGER_SAMPLER_TYPE
-              value: const
-            - name: JAEGER_SAMPLER_PARAM
-              value: "1"
-            - name: TRACING_SYSTEM
-              value: jaeger
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
     app: java-kafka-consumer
   name: java-kafka-consumer
 spec:

--- a/java/kafka/streams/src/main/java/KafkaStreamsExample.java
+++ b/java/kafka/streams/src/main/java/KafkaStreamsExample.java
@@ -46,7 +46,7 @@ public class KafkaStreamsExample {
                 KafkaClientSupplier supplier = new TracingKafkaClientSupplier();
                 streams = new KafkaStreams(builder.build(), props, supplier);
             } else {
-                throw new RuntimeException("Error: TRACING_SYSTEM jaeger is not recognized or supported!");
+                throw new RuntimeException("Error: TRACING_SYSTEM " + tracingSystem + " is not recognized or supported!");
             }
         } else {
             streams = new KafkaStreams(builder.build(), props);

--- a/java/kafka/streams/src/main/java/KafkaStreamsExample.java
+++ b/java/kafka/streams/src/main/java/KafkaStreamsExample.java
@@ -46,8 +46,7 @@ public class KafkaStreamsExample {
                 KafkaClientSupplier supplier = new TracingKafkaClientSupplier();
                 streams = new KafkaStreams(builder.build(), props, supplier);
             } else {
-                log.error("Error: TRACING_SYSTEM {} is not recognized or supported!", config.getTracingSystem());
-                streams = new KafkaStreams(builder.build(), props);
+                throw new RuntimeException("Error: TRACING_SYSTEM jaeger is not recognized or supported!");
             }
         } else {
             streams = new KafkaStreams(builder.build(), props);


### PR DESCRIPTION
Changed 2 things:

- Removed Jaeger / openTracing from Streams in deployment-tracing-jaeger.yaml
- Throw RuntimeError when jaeger is configured for Streams application  

