### PR TITLE
Refactor ConsumerConfig

### DIFF
--- a/java/kafka/consumer/src/main/java/KafkaConsumerExample.java
+++ b/java/kafka/consumer/src/main/java/KafkaConsumerExample.java
@@ -26,6 +26,8 @@ public class KafkaConsumerExample {
         Properties props = KafkaConsumerConfig.createProperties(config);
         int receivedMsgs = 0;
 
+
+
         TracingSystem tracingSystem = config.getTracingSystem();
         if (tracingSystem != TracingSystem.NONE) {
             if (tracingSystem == TracingSystem.JAEGER) {

--- a/java/kafka/deployment-tracing-jaeger.yaml
+++ b/java/kafka/deployment-tracing-jaeger.yaml
@@ -63,47 +63,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: java-kafka-streams
-  name: java-kafka-streams
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: java-kafka-streams
-  template:
-    metadata:
-      labels:
-        app: java-kafka-streams
-    spec:
-      containers:
-        - name: java-kafka-streams
-          image: quay.io/strimzi-examples/java-kafka-streams:latest
-          env:
-            - name: BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9092
-            - name: APPLICATION_ID
-              value: java-kafka-streams
-            - name: SOURCE_TOPIC
-              value: my-topic
-            - name: TARGET_TOPIC
-              value: my-topic-reversed
-            - name: LOG_LEVEL
-              value: "INFO"
-            - name: JAEGER_SERVICE_NAME
-              value: java-kafka-streams
-            - name: JAEGER_AGENT_HOST
-              value: my-jaeger-agent
-            - name: JAEGER_SAMPLER_TYPE
-              value: const
-            - name: JAEGER_SAMPLER_PARAM
-              value: "1"
-            - name: TRACING_SYSTEM
-              value: jaeger
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
     app: java-kafka-consumer
   name: java-kafka-consumer
 spec:

--- a/java/kafka/producer/src/main/java/KafkaProducerConfig.java
+++ b/java/kafka/producer/src/main/java/KafkaProducerConfig.java
@@ -4,107 +4,99 @@
  */
 
 import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Map;
 import java.util.Properties;
 import java.util.StringTokenizer;
+
+import static java.util.Map.entry;
 
 public class KafkaProducerConfig {
     private static final Logger log = LogManager.getLogger(KafkaProducerConfig.class);
 
     private static final long DEFAULT_MESSAGES_COUNT = 10;
     private static final String DEFAULT_MESSAGE = "Hello world";
-    private final String bootstrapServers;
+
     private final String topic;
     private final int delay;
     private final Long messageCount;
     private final String message;
-    private final String acks;
     private final String headers;
-    private final String sslTruststoreCertificates;
-    private final String sslKeystoreKey;
-    private final String sslKeystoreCertificateChain;
-    private final String oauthClientId;
-    private final String oauthClientSecret;
-    private final String oauthAccessToken;
-    private final String oauthRefreshToken;
-    private final String oauthTokenEndpointUri;
     private final String additionalConfig;
     private final String saslLoginCallbackClass = "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler";
     private final TracingSystem tracingSystem;
 
-    public KafkaProducerConfig(String bootstrapServers, String topic, int delay, Long messageCount, String message,
-                               String sslTruststoreCertificates, String sslKeystoreKey, String sslKeystoreCertificateChain,
-                               String oauthClientId, String oauthClientSecret, String oauthAccessToken, String oauthRefreshToken,
-                               String oauthTokenEndpointUri, String acks, String additionalConfig, String headers, TracingSystem tracingSystem) {
-        this.bootstrapServers = bootstrapServers;
+    private static final Map<String, String> DEFAULT_MAP = Map.ofEntries(
+            entry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer"),
+            entry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer"),
+            entry(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL"),
+            entry(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PEM"),
+            entry(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PEM"),
+            entry(SaslConfigs.SASL_JAAS_CONFIG, "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required"),
+            //  entry(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL"),
+            entry(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER")
+            //  entry(SaslConfigs.SASL_MECHANISM, "PLAIN")
+    );
+
+    public KafkaProducerConfig(String topic, int delay, Long messageCount, String message,
+                             String headers, String additionalConfig, TracingSystem tracingSystem) {
         this.topic = topic;
         this.delay = delay;
         this.messageCount = messageCount;
         this.message = message;
-        this.sslTruststoreCertificates = sslTruststoreCertificates;
-        this.sslKeystoreKey = sslKeystoreKey;
-        this.sslKeystoreCertificateChain = sslKeystoreCertificateChain;
-        this.oauthClientId = oauthClientId;
-        this.oauthClientSecret = oauthClientSecret;
-        this.oauthAccessToken = oauthAccessToken;
-        this.oauthRefreshToken = oauthRefreshToken;
-        this.oauthTokenEndpointUri = oauthTokenEndpointUri;
-        this.acks = acks;
         this.headers = headers;
         this.additionalConfig = additionalConfig;
         this.tracingSystem = tracingSystem;
     }
 
     public static KafkaProducerConfig fromEnv() {
-        String bootstrapServers = System.getenv("BOOTSTRAP_SERVERS");
         String topic = System.getenv("TOPIC");
         int delay = Integer.parseInt(System.getenv("DELAY_MS"));
         Long messageCount = System.getenv("MESSAGE_COUNT") == null ? DEFAULT_MESSAGES_COUNT : Long.parseLong(System.getenv("MESSAGE_COUNT"));
         String message = System.getenv("MESSAGE") == null ? DEFAULT_MESSAGE : System.getenv("MESSAGE");
-        String sslTruststoreCertificates = System.getenv("CA_CRT");
-        String sslKeystoreKey = System.getenv("USER_KEY");
-        String sslKeystoreCertificateChain = System.getenv("USER_CRT");
-        String oauthClientId = System.getenv("OAUTH_CLIENT_ID");
-        String oauthClientSecret = System.getenv("OAUTH_CLIENT_SECRET");
-        String oauthAccessToken = System.getenv("OAUTH_ACCESS_TOKEN");
-        String oauthRefreshToken = System.getenv("OAUTH_REFRESH_TOKEN");
-        String oauthTokenEndpointUri = System.getenv("OAUTH_TOKEN_ENDPOINT_URI");
-        String acks = System.getenv().getOrDefault("PRODUCER_ACKS", "1");
+
         String headers = System.getenv("HEADERS");
         String additionalConfig = System.getenv().getOrDefault("ADDITIONAL_CONFIG", "");
         TracingSystem tracingSystem = TracingSystem.forValue(System.getenv().getOrDefault("TRACING_SYSTEM", ""));
 
-        return new KafkaProducerConfig(bootstrapServers, topic, delay, messageCount, message, sslTruststoreCertificates,
-                sslKeystoreKey, sslKeystoreCertificateChain, oauthClientId, oauthClientSecret, oauthAccessToken, oauthRefreshToken,
-                oauthTokenEndpointUri, acks, additionalConfig, headers, tracingSystem);
+        return new KafkaProducerConfig(topic, delay, messageCount, message, additionalConfig, headers, tracingSystem);
     }
+    public static String convertEnvVarToPropertyKey(String propKey) {
+        propKey = propKey.substring(6).toLowerCase().replace("_", ".");
+        return propKey;
+    }
+
 
     public static Properties createProperties(KafkaProducerConfig config) {
         Properties props = new Properties();
-        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBootstrapServers());
-        props.put(ProducerConfig.ACKS_CONFIG, config.getAcks());
-        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
-        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
-
-        if (config.getSslTruststoreCertificates() != null)   {
-            log.info("Configuring truststore");
-            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
-            props.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PEM");
-            props.put(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, config.getSslTruststoreCertificates());
+        System.out.println("Printing translated key/value pairs");
+        Map<String, String> envVars = System.getenv();
+        for (Map.Entry<String, String> entry : envVars.entrySet()) {
+            if (entry.getKey().contains("KAFKA")) {
+                String key = convertEnvVarToPropertyKey(entry.getKey());
+                String value = entry.getValue();
+                System.out.println("key: " + key + " value: " + value);
+                props.put(key, value);
+            }
         }
 
-        if (config.getSslKeystoreCertificateChain() != null && config.getSslKeystoreKey() != null)   {
-            log.info("Configuring keystore");
-            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
-            props.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PEM");
-            props.put(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, config.getSslKeystoreCertificateChain());
-            props.put(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, config.getSslKeystoreKey());
+        System.out.println("Trap 0 " + DEFAULT_MAP);
+        for (Map.Entry<String, String> entry : DEFAULT_MAP.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            System.out.println("Trap 1 key: " + key + " value: " + value);
+            if (props.get(key) == null) {
+                props.put(key, value);
+                System.out.println("Trap 2 key: " + key + " value: " + value);
+            }
         }
+
 
         Properties additionalProps = new Properties();
         if (!config.getAdditionalConfig().isEmpty()) {
@@ -121,7 +113,7 @@ public class KafkaProducerConfig {
             }
         }
 
-        if ((config.getOauthAccessToken() != null)
+       /* if ((config.getOauthAccessToken() != null)
                 || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthRefreshToken() != null)
                 || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthClientSecret() != null))    {
             log.info("Configuring OAuth");
@@ -131,16 +123,12 @@ public class KafkaProducerConfig {
             if (!(additionalProps.containsKey(SaslConfigs.SASL_MECHANISM) && additionalProps.getProperty(SaslConfigs.SASL_MECHANISM).equals("PLAIN"))) {
                 props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, config.saslLoginCallbackClass);
             }
-        }
+        }*/
 
         // override properties with defined additional properties
         props.putAll(additionalProps);
 
         return props;
-    }
-
-    public String getBootstrapServers() {
-        return bootstrapServers;
     }
 
     public String getTopic() {
@@ -159,41 +147,6 @@ public class KafkaProducerConfig {
         return message;
     }
 
-    public String getAcks() {
-        return acks;
-    }
-
-    public String getSslTruststoreCertificates() {
-        return sslTruststoreCertificates;
-    }
-
-    public String getSslKeystoreKey() {
-        return sslKeystoreKey;
-    }
-
-    public String getSslKeystoreCertificateChain() {
-        return sslKeystoreCertificateChain;
-    }
-
-    public String getOauthClientId() {
-        return oauthClientId;
-    }
-
-    public String getOauthClientSecret() {
-        return oauthClientSecret;
-    }
-
-    public String getOauthAccessToken() {
-        return oauthAccessToken;
-    }
-
-    public String getOauthRefreshToken() {
-        return oauthRefreshToken;
-    }
-
-    public String getOauthTokenEndpointUri() {
-        return oauthTokenEndpointUri;
-    }
 
     public String getHeaders() {
         return headers;
@@ -210,21 +163,11 @@ public class KafkaProducerConfig {
     @Override
     public String toString() {
         return "KafkaProducerConfig{" +
-            "bootstrapServers='" + bootstrapServers + '\'' +
             ", topic='" + topic + '\'' +
             ", delay=" + delay +
             ", messageCount=" + messageCount +
             ", message='" + message + '\'' +
-            ", acks='" + acks + '\'' +
             ", headers='" + headers + '\'' +
-            ", sslTruststoreCertificates='" + sslTruststoreCertificates + '\'' +
-            ", sslKeystoreKey='" + sslKeystoreKey + '\'' +
-            ", sslKeystoreCertificateChain='" + sslKeystoreCertificateChain + '\'' +
-            ", oauthClientId='" + oauthClientId + '\'' +
-            ", oauthClientSecret='" + oauthClientSecret + '\'' +
-            ", oauthAccessToken='" + oauthAccessToken + '\'' +
-            ", oauthRefreshToken='" + oauthRefreshToken + '\'' +
-            ", oauthTokenEndpointUri='" + oauthTokenEndpointUri + '\'' +
             ", additionalConfig='" + additionalConfig + '\'' +
             ", tracingSystem='" + tracingSystem + '\'' +
             '}';

--- a/java/kafka/producer/src/main/java/KafkaProducerConfig.java
+++ b/java/kafka/producer/src/main/java/KafkaProducerConfig.java
@@ -4,99 +4,107 @@
  */
 
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Map;
 import java.util.Properties;
 import java.util.StringTokenizer;
-
-import static java.util.Map.entry;
 
 public class KafkaProducerConfig {
     private static final Logger log = LogManager.getLogger(KafkaProducerConfig.class);
 
     private static final long DEFAULT_MESSAGES_COUNT = 10;
     private static final String DEFAULT_MESSAGE = "Hello world";
-
+    private final String bootstrapServers;
     private final String topic;
     private final int delay;
     private final Long messageCount;
     private final String message;
+    private final String acks;
     private final String headers;
+    private final String sslTruststoreCertificates;
+    private final String sslKeystoreKey;
+    private final String sslKeystoreCertificateChain;
+    private final String oauthClientId;
+    private final String oauthClientSecret;
+    private final String oauthAccessToken;
+    private final String oauthRefreshToken;
+    private final String oauthTokenEndpointUri;
     private final String additionalConfig;
     private final String saslLoginCallbackClass = "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler";
     private final TracingSystem tracingSystem;
 
-    private static final Map<String, String> DEFAULT_MAP = Map.ofEntries(
-            entry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer"),
-            entry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer"),
-            entry(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL"),
-            entry(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PEM"),
-            entry(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PEM"),
-            entry(SaslConfigs.SASL_JAAS_CONFIG, "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required"),
-            //  entry(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL"),
-            entry(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER")
-            //  entry(SaslConfigs.SASL_MECHANISM, "PLAIN")
-    );
-
-    public KafkaProducerConfig(String topic, int delay, Long messageCount, String message,
-                             String headers, String additionalConfig, TracingSystem tracingSystem) {
+    public KafkaProducerConfig(String bootstrapServers, String topic, int delay, Long messageCount, String message,
+                               String sslTruststoreCertificates, String sslKeystoreKey, String sslKeystoreCertificateChain,
+                               String oauthClientId, String oauthClientSecret, String oauthAccessToken, String oauthRefreshToken,
+                               String oauthTokenEndpointUri, String acks, String additionalConfig, String headers, TracingSystem tracingSystem) {
+        this.bootstrapServers = bootstrapServers;
         this.topic = topic;
         this.delay = delay;
         this.messageCount = messageCount;
         this.message = message;
+        this.sslTruststoreCertificates = sslTruststoreCertificates;
+        this.sslKeystoreKey = sslKeystoreKey;
+        this.sslKeystoreCertificateChain = sslKeystoreCertificateChain;
+        this.oauthClientId = oauthClientId;
+        this.oauthClientSecret = oauthClientSecret;
+        this.oauthAccessToken = oauthAccessToken;
+        this.oauthRefreshToken = oauthRefreshToken;
+        this.oauthTokenEndpointUri = oauthTokenEndpointUri;
+        this.acks = acks;
         this.headers = headers;
         this.additionalConfig = additionalConfig;
         this.tracingSystem = tracingSystem;
     }
 
     public static KafkaProducerConfig fromEnv() {
+        String bootstrapServers = System.getenv("BOOTSTRAP_SERVERS");
         String topic = System.getenv("TOPIC");
         int delay = Integer.parseInt(System.getenv("DELAY_MS"));
         Long messageCount = System.getenv("MESSAGE_COUNT") == null ? DEFAULT_MESSAGES_COUNT : Long.parseLong(System.getenv("MESSAGE_COUNT"));
         String message = System.getenv("MESSAGE") == null ? DEFAULT_MESSAGE : System.getenv("MESSAGE");
-
+        String sslTruststoreCertificates = System.getenv("CA_CRT");
+        String sslKeystoreKey = System.getenv("USER_KEY");
+        String sslKeystoreCertificateChain = System.getenv("USER_CRT");
+        String oauthClientId = System.getenv("OAUTH_CLIENT_ID");
+        String oauthClientSecret = System.getenv("OAUTH_CLIENT_SECRET");
+        String oauthAccessToken = System.getenv("OAUTH_ACCESS_TOKEN");
+        String oauthRefreshToken = System.getenv("OAUTH_REFRESH_TOKEN");
+        String oauthTokenEndpointUri = System.getenv("OAUTH_TOKEN_ENDPOINT_URI");
+        String acks = System.getenv().getOrDefault("PRODUCER_ACKS", "1");
         String headers = System.getenv("HEADERS");
         String additionalConfig = System.getenv().getOrDefault("ADDITIONAL_CONFIG", "");
         TracingSystem tracingSystem = TracingSystem.forValue(System.getenv().getOrDefault("TRACING_SYSTEM", ""));
 
-        return new KafkaProducerConfig(topic, delay, messageCount, message, additionalConfig, headers, tracingSystem);
+        return new KafkaProducerConfig(bootstrapServers, topic, delay, messageCount, message, sslTruststoreCertificates,
+                sslKeystoreKey, sslKeystoreCertificateChain, oauthClientId, oauthClientSecret, oauthAccessToken, oauthRefreshToken,
+                oauthTokenEndpointUri, acks, additionalConfig, headers, tracingSystem);
     }
-    public static String convertEnvVarToPropertyKey(String propKey) {
-        propKey = propKey.substring(6).toLowerCase().replace("_", ".");
-        return propKey;
-    }
-
 
     public static Properties createProperties(KafkaProducerConfig config) {
         Properties props = new Properties();
-        System.out.println("Printing translated key/value pairs");
-        Map<String, String> envVars = System.getenv();
-        for (Map.Entry<String, String> entry : envVars.entrySet()) {
-            if (entry.getKey().contains("KAFKA")) {
-                String key = convertEnvVarToPropertyKey(entry.getKey());
-                String value = entry.getValue();
-                System.out.println("key: " + key + " value: " + value);
-                props.put(key, value);
-            }
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBootstrapServers());
+        props.put(ProducerConfig.ACKS_CONFIG, config.getAcks());
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
+
+        if (config.getSslTruststoreCertificates() != null)   {
+            log.info("Configuring truststore");
+            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
+            props.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PEM");
+            props.put(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, config.getSslTruststoreCertificates());
         }
 
-        System.out.println("Trap 0 " + DEFAULT_MAP);
-        for (Map.Entry<String, String> entry : DEFAULT_MAP.entrySet()) {
-            String key = entry.getKey();
-            String value = entry.getValue();
-            System.out.println("Trap 1 key: " + key + " value: " + value);
-            if (props.get(key) == null) {
-                props.put(key, value);
-                System.out.println("Trap 2 key: " + key + " value: " + value);
-            }
+        if (config.getSslKeystoreCertificateChain() != null && config.getSslKeystoreKey() != null)   {
+            log.info("Configuring keystore");
+            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
+            props.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PEM");
+            props.put(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, config.getSslKeystoreCertificateChain());
+            props.put(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, config.getSslKeystoreKey());
         }
-
 
         Properties additionalProps = new Properties();
         if (!config.getAdditionalConfig().isEmpty()) {
@@ -113,7 +121,7 @@ public class KafkaProducerConfig {
             }
         }
 
-       /* if ((config.getOauthAccessToken() != null)
+        if ((config.getOauthAccessToken() != null)
                 || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthRefreshToken() != null)
                 || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthClientSecret() != null))    {
             log.info("Configuring OAuth");
@@ -123,12 +131,16 @@ public class KafkaProducerConfig {
             if (!(additionalProps.containsKey(SaslConfigs.SASL_MECHANISM) && additionalProps.getProperty(SaslConfigs.SASL_MECHANISM).equals("PLAIN"))) {
                 props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, config.saslLoginCallbackClass);
             }
-        }*/
+        }
 
         // override properties with defined additional properties
         props.putAll(additionalProps);
 
         return props;
+    }
+
+    public String getBootstrapServers() {
+        return bootstrapServers;
     }
 
     public String getTopic() {
@@ -147,6 +159,41 @@ public class KafkaProducerConfig {
         return message;
     }
 
+    public String getAcks() {
+        return acks;
+    }
+
+    public String getSslTruststoreCertificates() {
+        return sslTruststoreCertificates;
+    }
+
+    public String getSslKeystoreKey() {
+        return sslKeystoreKey;
+    }
+
+    public String getSslKeystoreCertificateChain() {
+        return sslKeystoreCertificateChain;
+    }
+
+    public String getOauthClientId() {
+        return oauthClientId;
+    }
+
+    public String getOauthClientSecret() {
+        return oauthClientSecret;
+    }
+
+    public String getOauthAccessToken() {
+        return oauthAccessToken;
+    }
+
+    public String getOauthRefreshToken() {
+        return oauthRefreshToken;
+    }
+
+    public String getOauthTokenEndpointUri() {
+        return oauthTokenEndpointUri;
+    }
 
     public String getHeaders() {
         return headers;
@@ -163,13 +210,23 @@ public class KafkaProducerConfig {
     @Override
     public String toString() {
         return "KafkaProducerConfig{" +
-            ", topic='" + topic + '\'' +
-            ", delay=" + delay +
-            ", messageCount=" + messageCount +
-            ", message='" + message + '\'' +
-            ", headers='" + headers + '\'' +
-            ", additionalConfig='" + additionalConfig + '\'' +
-            ", tracingSystem='" + tracingSystem + '\'' +
-            '}';
+                "bootstrapServers='" + bootstrapServers + '\'' +
+                ", topic='" + topic + '\'' +
+                ", delay=" + delay +
+                ", messageCount=" + messageCount +
+                ", message='" + message + '\'' +
+                ", acks='" + acks + '\'' +
+                ", headers='" + headers + '\'' +
+                ", sslTruststoreCertificates='" + sslTruststoreCertificates + '\'' +
+                ", sslKeystoreKey='" + sslKeystoreKey + '\'' +
+                ", sslKeystoreCertificateChain='" + sslKeystoreCertificateChain + '\'' +
+                ", oauthClientId='" + oauthClientId + '\'' +
+                ", oauthClientSecret='" + oauthClientSecret + '\'' +
+                ", oauthAccessToken='" + oauthAccessToken + '\'' +
+                ", oauthRefreshToken='" + oauthRefreshToken + '\'' +
+                ", oauthTokenEndpointUri='" + oauthTokenEndpointUri + '\'' +
+                ", additionalConfig='" + additionalConfig + '\'' +
+                ", tracingSystem='" + tracingSystem + '\'' +
+                '}';
     }
 }

--- a/java/kafka/streams/src/main/java/KafkaStreamsExample.java
+++ b/java/kafka/streams/src/main/java/KafkaStreamsExample.java
@@ -46,7 +46,7 @@ public class KafkaStreamsExample {
                 KafkaClientSupplier supplier = new TracingKafkaClientSupplier();
                 streams = new KafkaStreams(builder.build(), props, supplier);
             } else {
-                throw new RuntimeException("Error: TRACING_SYSTEM jaeger is not recognized or supported!");
+                throw new RuntimeException("Error: TRACING_SYSTEM " + tracingSystem + " is not recognized or supported!");
             }
         } else {
             streams = new KafkaStreams(builder.build(), props);

--- a/java/kafka/streams/src/main/java/KafkaStreamsExample.java
+++ b/java/kafka/streams/src/main/java/KafkaStreamsExample.java
@@ -46,8 +46,7 @@ public class KafkaStreamsExample {
                 KafkaClientSupplier supplier = new TracingKafkaClientSupplier();
                 streams = new KafkaStreams(builder.build(), props, supplier);
             } else {
-                log.error("Error: TRACING_SYSTEM {} is not recognized or supported!", config.getTracingSystem());
-                streams = new KafkaStreams(builder.build(), props);
+                throw new RuntimeException("Error: TRACING_SYSTEM jaeger is not recognized or supported!");
             }
         } else {
             streams = new KafkaStreams(builder.build(), props);


### PR DESCRIPTION
Refactor the ConsumerConfig files in the Java client by reducing the complexity and size of the class. Standardise the naming scheme of environment variables used to configure the clients / standardise the envVars used to configure the Kafka client properties as outlined here [1].


Example of standardised Environmental Variables:
``` 
KAFKA_<NAME_OF_KAFKA_PROPERTY_DELIMITED_BY_UNDERSCORES>
```

[1]  https://github.com/kyguy/proposals/blob/refactor-client-examples/040-refactor-client-examples.md