### PR TITLE
Revert "Refactor Client-Example ConsumerConfigs"

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ To run the OAuth example, you will need to have your Kafka cluster configured wi
 
 ## Configuration
 
-Below are listed and described the available environment variables that can be used for configuration.
+Although this Hello World is simple example it is fully configurable.
+Below are listed and described environmental variables.
 
 Producer  
 * `BOOTSTRAP_SERVERS` - comma-separated host and port pairs that is a list of Kafka broker addresses. The form of pair is `host:port`, e.g. `my-cluster-kafka-bootstrap:9092` 
@@ -75,14 +76,16 @@ Producer
 * `TRACING_SYSTEM` - if it's set to `jaeger` or `opentelemetry`, this will enable tracing. 
 
 Consumer  
-* `STRIMZI_TOPIC` - name of topic which consumer subscribes  
-* `STRIMZI_MESSAGE_COUNT` - the number of messages the consumer should receive
-* `STRIMZI_LOG_LEVEL` - logging level  
-* `STRIMZI_TRACING_SYSTEM` - if it's set to `jaeger` or `opentelemetry`, this will enable tracing.
-
-Additionally, any Kafka Consumer API configuration option can be passed as an environmental variable.
-It should be prefixed with `KAFKA_` and use `_` instead of `.`.
-For example environment variable `KAFKA_BOOTSTRAP_SERVERS` will be used as the `bootstrap.servers` configuration option in the Kafka Consumer API.
+* `BOOTSTRAP_SERVERS` - comma-separated host and port pairs that is a list of Kafka broker addresses. The form of pair is `host:port`, e.g. `my-cluster-kafka-bootstrap:9092` 
+* `TOPIC` - name of topic which consumer subscribes  
+* `GROUP_ID` - specifies the consumer group id for the consumer
+* `MESSAGE_COUNT` - the number of messages the consumer should receive
+* `CA_CRT` - the certificate of the CA which signed the brokers' TLS certificates, for adding to the client's trust store
+* `USER_CRT` - the user's certificate
+* `USER_KEY` - the user's private key
+* `LOG_LEVEL` - logging level  
+* `ADDITIONAL_CONFIG` - additional configuration for a consumer application. Notice, that you can also override any previously set variable by setting this. The form is `key=value` records separated by new line character
+* `TRACING_SYSTEM` - if it's set to `jaeger` or `opentelemetry`, this will enable tracing.
 
 Streams  
 * `BOOTSTRAP_SERVERS` - comma-separated host and port pairs that is a list of Kafka broker addresses. The form of pair is `host:port`, e.g. `my-cluster-kafka-bootstrap:9092`

--- a/java/kafka/consumer/src/main/java/KafkaConsumerConfig.java
+++ b/java/kafka/consumer/src/main/java/KafkaConsumerConfig.java
@@ -3,56 +3,228 @@
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 
-import java.util.Map;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.Properties;
-import java.util.stream.Collectors;
+import java.util.StringTokenizer;
 
 public class KafkaConsumerConfig {
+    private static final Logger log = LogManager.getLogger(KafkaConsumerConfig.class);
+
     private static final long DEFAULT_MESSAGES_COUNT = 10;
-    private static final String KAFKA_PREFIX = "KAFKA_";
-
+    private final String bootstrapServers;
     private final String topic;
+    private final String groupId;
+    private final String autoOffsetReset = "earliest";
+    private final String enableAutoCommit = "false";
+    private final String clientRack;
     private final Long messageCount;
+    private final String sslTruststoreCertificates;
+    private final String sslKeystoreKey;
+    private final String sslKeystoreCertificateChain;
+    private final String oauthClientId;
+    private final String oauthClientSecret;
+    private final String oauthAccessToken;
+    private final String oauthRefreshToken;
+    private final String oauthTokenEndpointUri;
+    private final String additionalConfig;
+    private final String saslLoginCallbackClass = "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler";
     private final TracingSystem tracingSystem;
-    private final Properties properties;
 
-    public KafkaConsumerConfig(String topic, Long messageCount, TracingSystem tracingSystem, Properties properties) {
+    public KafkaConsumerConfig(String bootstrapServers, String topic, String groupId, String clientRack, Long messageCount,
+                               String sslTruststoreCertificates, String sslKeystoreKey, String sslKeystoreCertificateChain,
+                               String oauthClientId, String oauthClientSecret, String oauthAccessToken, String oauthRefreshToken,
+                               String oauthTokenEndpointUri, String additionalConfig, TracingSystem tracingSystem) {
+        this.bootstrapServers = bootstrapServers;
         this.topic = topic;
+        this.groupId = groupId;
+        this.clientRack = clientRack;
         this.messageCount = messageCount;
+        this.sslTruststoreCertificates = sslTruststoreCertificates;
+        this.sslKeystoreKey = sslKeystoreKey;
+        this.sslKeystoreCertificateChain = sslKeystoreCertificateChain;
+        this.oauthClientId = oauthClientId;
+        this.oauthClientSecret = oauthClientSecret;
+        this.oauthAccessToken = oauthAccessToken;
+        this.oauthRefreshToken = oauthRefreshToken;
+        this.oauthTokenEndpointUri = oauthTokenEndpointUri;
+        this.additionalConfig = additionalConfig;
         this.tracingSystem = tracingSystem;
-        this.properties = properties;
     }
 
     public static KafkaConsumerConfig fromEnv() {
-        String topic = System.getenv("STRIMZI_TOPIC");
-        Long messageCount = System.getenv("STRIMZI_MESSAGE_COUNT") == null ? DEFAULT_MESSAGES_COUNT : Long.parseLong(System.getenv("STRIMZI_MESSAGE_COUNT"));
-        TracingSystem tracingSystem = TracingSystem.forValue(System.getenv().getOrDefault("STRIMZI_TRACING_SYSTEM", ""));
-        Properties properties = new Properties();
-        properties.putAll(System.getenv()
-                .entrySet()
-                .stream()
-                .filter(mapEntry -> mapEntry.getKey().startsWith(KAFKA_PREFIX))
-                .collect(Collectors.toMap(mapEntry -> convertEnvVarToPropertyKey(mapEntry.getKey()), Map.Entry::getValue)));
-        return new KafkaConsumerConfig(topic, messageCount, tracingSystem, properties);
+        String bootstrapServers = System.getenv("BOOTSTRAP_SERVERS");
+        String topic = System.getenv("TOPIC");
+        String groupId = System.getenv("GROUP_ID");
+        String clientRack = System.getenv("CLIENT_RACK");
+        Long messageCount = System.getenv("MESSAGE_COUNT") == null ? DEFAULT_MESSAGES_COUNT : Long.parseLong(System.getenv("MESSAGE_COUNT"));
+        String sslTruststoreCertificates = System.getenv("CA_CRT");
+        String sslKeystoreKey = System.getenv("USER_KEY");
+        String sslKeystoreCertificateChain = System.getenv("USER_CRT");
+        String oauthClientId = System.getenv("OAUTH_CLIENT_ID");
+        String oauthClientSecret = System.getenv("OAUTH_CLIENT_SECRET");
+        String oauthAccessToken = System.getenv("OAUTH_ACCESS_TOKEN");
+        String oauthRefreshToken = System.getenv("OAUTH_REFRESH_TOKEN");
+        String oauthTokenEndpointUri = System.getenv("OAUTH_TOKEN_ENDPOINT_URI");
+        String additionalConfig = System.getenv().getOrDefault("ADDITIONAL_CONFIG", "");
+        TracingSystem tracingSystem = TracingSystem.forValue(System.getenv().getOrDefault("TRACING_SYSTEM", ""));
+
+        return new KafkaConsumerConfig(bootstrapServers, topic, groupId, clientRack, messageCount, sslTruststoreCertificates, sslKeystoreKey,
+                sslKeystoreCertificateChain, oauthClientId, oauthClientSecret, oauthAccessToken, oauthRefreshToken, oauthTokenEndpointUri,
+                additionalConfig, tracingSystem);
     }
 
-    private static String convertEnvVarToPropertyKey(String envVar) {
-        return envVar.substring(envVar.indexOf("_") + 1).toLowerCase().replace("_", ".");
+    public static Properties createProperties(KafkaConsumerConfig config) {
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBootstrapServers());
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, config.getGroupId());
+        if (config.getClientRack() != null) {
+            props.put(ConsumerConfig.CLIENT_RACK_CONFIG, config.getClientRack());
+        }
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, config.getAutoOffsetReset());
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, config.getEnableAutoCommit());
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
+
+        if (config.getSslTruststoreCertificates() != null)   {
+            log.info("Configuring truststore");
+            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
+            props.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PEM");
+            props.put(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, config.getSslTruststoreCertificates());
+        }
+
+        if (config.getSslKeystoreCertificateChain() != null && config.getSslKeystoreKey() != null)   {
+            log.info("Configuring keystore");
+            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
+            props.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PEM");
+            props.put(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, config.getSslKeystoreCertificateChain());
+            props.put(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, config.getSslKeystoreKey());
+        }
+
+        Properties additionalProps = new Properties();
+        if (!config.getAdditionalConfig().isEmpty()) {
+            StringTokenizer tok = new StringTokenizer(config.getAdditionalConfig(), System.lineSeparator());
+            while (tok.hasMoreTokens()) {
+                String record = tok.nextToken();
+                int endIndex = record.indexOf('=');
+                if (endIndex == -1) {
+                    throw new RuntimeException("Failed to parse Map from String");
+                }
+                String key = record.substring(0, endIndex);
+                String value = record.substring(endIndex + 1);
+                additionalProps.put(key.trim(), value.trim());
+            }
+        }
+
+        if ((config.getOauthAccessToken() != null)
+                || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthRefreshToken() != null)
+                || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthClientSecret() != null))    {
+            log.info("Configuring OAuth");
+            props.put(SaslConfigs.SASL_JAAS_CONFIG, "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;");
+            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL".equals(props.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)) ? "SASL_SSL" : "SASL_PLAINTEXT");
+            props.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
+            if (!(additionalProps.containsKey(SaslConfigs.SASL_MECHANISM) && additionalProps.getProperty(SaslConfigs.SASL_MECHANISM).equals("PLAIN"))) {
+                props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, config.saslLoginCallbackClass);
+            }
+        }
+
+        // override properties with defined additional properties
+        props.putAll(additionalProps);
+
+        return props;
+    }
+
+    public String getBootstrapServers() {
+        return bootstrapServers;
     }
 
     public String getTopic() {
         return topic;
     }
 
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public String getAutoOffsetReset() {
+        return autoOffsetReset;
+    }
+
+    public String getEnableAutoCommit() {
+        return enableAutoCommit;
+    }
+
+    public String getClientRack() {
+        return clientRack;
+    }
+
     public Long getMessageCount() {
         return messageCount;
     }
 
-    public TracingSystem getTracingSystem() {
-        return tracingSystem;
+    public String getSslTruststoreCertificates() {
+        return sslTruststoreCertificates;
     }
 
-    public Properties getProperties() {
-        return properties;
+    public String getSslKeystoreKey() {
+        return sslKeystoreKey;
+    }
+
+    public String getSslKeystoreCertificateChain() {
+        return sslKeystoreCertificateChain;
+    }
+
+    public String getOauthClientId() {
+        return oauthClientId;
+    }
+
+    public String getOauthClientSecret() {
+        return oauthClientSecret;
+    }
+
+    public String getOauthAccessToken() {
+        return oauthAccessToken;
+    }
+
+    public String getOauthRefreshToken() {
+        return oauthRefreshToken;
+    }
+
+    public String getOauthTokenEndpointUri() {
+        return oauthTokenEndpointUri;
+    }
+
+    public String getAdditionalConfig() {
+        return additionalConfig;
+    }
+
+    public TracingSystem getTracingSystem() { return tracingSystem; }
+
+    @Override
+    public String toString() {
+        return "KafkaConsumerConfig{" +
+            "bootstrapServers='" + bootstrapServers + '\'' +
+            ", topic='" + topic + '\'' +
+            ", groupId='" + groupId + '\'' +
+            ", autoOffsetReset='" + autoOffsetReset + '\'' +
+            ", enableAutoCommit='" + enableAutoCommit + '\'' +
+            ", clientRack='" + clientRack + '\'' +
+            ", messageCount=" + messageCount +
+            ", sslTruststoreCertificates='" + sslTruststoreCertificates + '\'' +
+            ", sslKeystoreKey='" + sslKeystoreKey + '\'' +
+            ", sslKeystoreCertificateChain='" + sslKeystoreCertificateChain + '\'' +
+            ", oauthClientId='" + oauthClientId + '\'' +
+            ", oauthClientSecret='" + oauthClientSecret + '\'' +
+            ", oauthAccessToken='" + oauthAccessToken + '\'' +
+            ", oauthRefreshToken='" + oauthRefreshToken + '\'' +
+            ", oauthTokenEndpointUri='" + oauthTokenEndpointUri + '\'' +
+            ", additionalConfig='" + additionalConfig + '\'' +
+            ", tracingSystem='" + tracingSystem + '\'' +
+            '}';
     }
 }

--- a/java/kafka/consumer/src/main/java/KafkaConsumerExample.java
+++ b/java/kafka/consumer/src/main/java/KafkaConsumerExample.java
@@ -15,8 +15,6 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Properties;
 
-import static org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG;
-
 public class KafkaConsumerExample {
     private static final Logger log = LogManager.getLogger(KafkaConsumerExample.class);
 
@@ -25,7 +23,7 @@ public class KafkaConsumerExample {
 
         log.info(KafkaConsumerConfig.class.getName() + ": {}", config.toString());
 
-        Properties props = config.getProperties();
+        Properties props = KafkaConsumerConfig.createProperties(config);
         int receivedMsgs = 0;
 
         TracingSystem tracingSystem = config.getTracingSystem();
@@ -43,7 +41,7 @@ public class KafkaConsumerExample {
             }
         }
 
-        boolean commit = !Boolean.parseBoolean(props.getProperty(ENABLE_AUTO_COMMIT_CONFIG));
+        boolean commit = !Boolean.parseBoolean(config.getEnableAutoCommit());
         KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props);
         consumer.subscribe(Collections.singletonList(config.getTopic()));
 

--- a/java/kafka/deployment-oauth.yaml
+++ b/java/kafka/deployment-oauth.yaml
@@ -238,15 +238,15 @@ spec:
         - name: java-kafka-consumer
           image: quay.io/strimzi-examples/java-kafka-consumer:latest
           env:
-            - name: KAFKA_BOOTSTRAP_SERVERS
+            - name: BOOTSTRAP_SERVERS
               value: my-cluster-kafka-bootstrap:9092
-            - name: STRIMZI_TOPIC
+            - name: TOPIC
               value: my-topic-reversed
-            - name: KAFKA_GROUP_ID
+            - name: GROUP_ID
               value: java-kafka-consumer
-            - name: STRIMZI_LOG_LEVEL
+            - name: LOG_LEVEL
               value: "INFO"
-            - name: STRIMZI_MESSAGE_COUNT
+            - name: MESSAGE_COUNT
               value: "1000000"
             - name: OAUTH_CLIENT_ID
               value: java-kafka-consumer

--- a/java/kafka/deployment-ssl-auth.yaml
+++ b/java/kafka/deployment-ssl-auth.yaml
@@ -218,28 +218,28 @@ spec:
       - name: java-kafka-consumer
         image: quay.io/strimzi-examples/java-kafka-consumer:latest
         env:
-          - name: KAFKA_TRUSTSTORE_CERTIFICATE
+          - name: CA_CRT
             valueFrom:
               secretKeyRef:
                 name: my-cluster-cluster-ca-cert
                 key: ca.crt
-          - name: KAFKA_KEYSTORE_CERTIFICATE_CHAIN
+          - name: USER_CRT
             valueFrom:
               secretKeyRef:
                 name: java-kafka-consumer
                 key: user.crt
-          - name: KAFKA_KEYSTORE_CERTIFICATE_CHAIN
+          - name: USER_KEY
             valueFrom:
               secretKeyRef:
                 name: java-kafka-consumer
                 key: user.key
-          - name: KAFKA_BOOTSTRAP_SERVERS
+          - name: BOOTSTRAP_SERVERS
             value: my-cluster-kafka-bootstrap:9093
-          - name: STRIMZI_TOPIC
+          - name: TOPIC
             value: my-topic-reversed
-          - name: STRIMZI_GROUP_ID
+          - name: GROUP_ID
             value: java-kafka-consumer
-          - name: STRIMZI_LOG_LEVEL
+          - name: LOG_LEVEL
             value: "INFO"
-          - name: STRIMZI_MESSAGE_COUNT
+          - name: MESSAGE_COUNT
             value: "1000000"

--- a/java/kafka/deployment-ssl.yaml
+++ b/java/kafka/deployment-ssl.yaml
@@ -110,18 +110,18 @@ spec:
       - name: java-kafka-consumer
         image: quay.io/strimzi-examples/java-kafka-consumer:latest
         env:
-          - name: KAFKA_TRUSTSTORE_CERTIFICATE
+          - name: CA_CRT
             valueFrom:
               secretKeyRef:
                 name: my-cluster-cluster-ca-cert
                 key: ca.crt
-          - name: KAFKA_BOOTSTRAP_SERVERS
+          - name: BOOTSTRAP_SERVERS
             value: my-cluster-kafka-bootstrap:9093
-          - name: STRIMZI_TOPIC
+          - name: TOPIC
             value: my-topic-reversed
-          - name: KAFKA_GROUP_ID
+          - name: GROUP_ID
             value: java-kafka-consumer
-          - name: STRIMZI_LOG_LEVEL
+          - name: LOG_LEVEL
             value: "INFO"
-          - name: STRIMZI_MESSAGE_COUNT
+          - name: MESSAGE_COUNT
             value: "1000000"

--- a/java/kafka/deployment-tracing-jaeger.yaml
+++ b/java/kafka/deployment-tracing-jaeger.yaml
@@ -79,15 +79,15 @@ spec:
         - name: java-kafka-consumer
           image: quay.io/strimzi-examples/java-kafka-consumer:latest
           env:
-            - name: KAFKA_BOOTSTRAP_SERVERS
+            - name: BOOTSTRAP_SERVERS
               value: my-cluster-kafka-bootstrap:9092
-            - name: STRIMZI_TOPIC
+            - name: TOPIC
               value: my-topic-reversed
-            - name: KAFKA_GROUP_ID
+            - name: GROUP_ID
               value: java-kafka-consumer
-            - name: STRIMZI_LOG_LEVEL
+            - name: LOG_LEVEL
               value: "INFO"
-            - name: STRIMZI_MESSAGE_COUNT
+            - name: MESSAGE_COUNT
               value: "1000000"
             - name: JAEGER_SERVICE_NAME
               value: java-kafka-consumer

--- a/java/kafka/deployment-tracing-opentelemetry.yaml
+++ b/java/kafka/deployment-tracing-opentelemetry.yaml
@@ -120,15 +120,15 @@ spec:
         - name: java-kafka-consumer
           image: quay.io/strimzi-examples/java-kafka-consumer:latest
           env:
-            - name: KAFKA_BOOTSTRAP_SERVERS
+            - name: BOOTSTRAP_SERVERS
               value: my-cluster-kafka-bootstrap:9092
-            - name: STRIMZI_TOPIC
+            - name: TOPIC
               value: my-topic-reversed
-            - name: KAFKA_GROUP_ID
+            - name: GROUP_ID
               value: java-kafka-consumer
-            - name: STRIMZI_LOG_LEVEL
+            - name: LOG_LEVEL
               value: "INFO"
-            - name: STRIMZI_MESSAGE_COUNT
+            - name: MESSAGE_COUNT
               value: "1000000"
             - name: OTEL_SERVICE_NAME
               value: kafka-otel

--- a/java/kafka/deployment.yaml
+++ b/java/kafka/deployment.yaml
@@ -100,13 +100,13 @@ spec:
         - name: java-kafka-consumer
           image: quay.io/strimzi-examples/java-kafka-consumer:latest
           env:
-            - name: KAFKA_BOOTSTRAP_SERVERS
+            - name: BOOTSTRAP_SERVERS
               value: my-cluster-kafka-bootstrap:9092
-            - name: STRIMZI_TOPIC
+            - name: TOPIC
               value: my-topic-reversed
-            - name: KAFKA_GROUP_ID
+            - name: GROUP_ID
               value: java-kafka-consumer
-            - name: STRIMZI_LOG_LEVEL
+            - name: LOG_LEVEL
               value: "INFO"
-            - name: STRIMZI_MESSAGE_COUNT
+            - name: MESSAGE_COUNT
               value: "1000000"

--- a/java/kafka/java-kafka-consumer.yaml
+++ b/java/kafka/java-kafka-consumer.yaml
@@ -18,13 +18,16 @@ spec:
       - name: java-kafka-consumer
         image: quay.io/strimzi-examples/java-kafka-consumer:latest
         env:
-          - name: KAFKA_BOOTSTRAP_SERVERS
+          - name: BOOTSTRAP_SERVERS
             value: my-cluster-kafka-bootstrap:9092
-          - name: STRIMZI_TOPIC
+          - name: TOPIC
             value: my-topic
-          - name: KAFKA_GROUP_ID
+          - name: GROUP_ID
             value: my-java-kafka-consumer
-          - name: STRIMZI_LOG_LEVEL
+          - name: LOG_LEVEL
             value: "INFO"
-          - name: STRIMZI_MESSAGE_COUNT
+          - name: MESSAGE_COUNT
             value: "1000000"
+          - name: ADDITIONAL_CONFIG
+            value: |
+              max.poll.records=100


### PR DESCRIPTION
There seem to be many issues with how the code introduced in #91 actually works - not as much in the code itself but in the example YAMLs. They are missing deserializers, the TLS configuration is completely wrong etc. This PR reverts that PR - we should get back to it, fix the YAMLs and test them properly.