### PR TITLE
Refactor Client-Examples ProducerConfigs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,20 +59,13 @@ To run the OAuth example, you will need to have your Kafka cluster configured wi
 Below are listed and described the available environment variables that can be used for configuration.
 
 Producer  
-* `BOOTSTRAP_SERVERS` - comma-separated host and port pairs that is a list of Kafka broker addresses. The form of pair is `host:port`, e.g. `my-cluster-kafka-bootstrap:9092` 
-* `TOPIC` - the topic the producer will send to  
-* `DELAY_MS` - the delay, in ms, between messages  
-* `MESSAGE_COUNT` - the number of messages the producer should send  
-* `CA_CRT` - the certificate of the CA which signed the brokers' TLS certificates, for adding to the client's trust store
-* `USER_CRT` - the user's certificate
-* `USER_KEY` - the user's private key
-* `LOG_LEVEL` - logging level  
-* `PRODUCER_ACKS` - acknowledgement level
-* `HEADERS` - custom headers list separated by commas of `key1=value1, key2=value2`
-* `BLOCKING_PRODUCER` - if it's set, the producer will block another message until ack will be received
-* `MESSAGES_PER_TRANSACTION` - how many messages will be part of one transaction. Transaction config could be set via `ADDITIONAL_CONFIG` variable. Default is 10.
-* `ADDITIONAL_CONFIG` - additional configuration for a producer application. Notice, that you can also override any previously set variable by setting this. The form is `key=value` records separated by new line character
-* `TRACING_SYSTEM` - if it's set to `jaeger` or `opentelemetry`, this will enable tracing. 
+* `STRIMZI_TOPIC` - the topic the producer will send to  
+* `STRIMZI_DELAY_MS` - the delay, in ms, between messages  
+* `STRIMZI_MESSAGE_COUNT` - the number of messages the producer should send
+* `STRIMZI_MESSAGE` - the message the producer will send
+* `STRIMZI_LOG_LEVEL` - logging level  
+* `STRIMZI_HEADERS` - custom headers list separated by commas of `key1=value1, key2=value2`
+* `STRIMZI_TRACING_SYSTEM` - if it's set to `jaeger` or `opentelemetry`, this will enable tracing. 
 
 Consumer  
 * `STRIMZI_TOPIC` - name of topic which consumer subscribes  
@@ -80,7 +73,7 @@ Consumer
 * `STRIMZI_LOG_LEVEL` - logging level  
 * `STRIMZI_TRACING_SYSTEM` - if it's set to `jaeger` or `opentelemetry`, this will enable tracing.
 
-Additionally, any Kafka Consumer API configuration option can be passed as an environment variable.
+Additionally, any Kafka Consumer API or Kafka Producer API configuration option can be passed as an environment variable.
 It should be prefixed with `KAFKA_` and use `_` instead of `.`.
 For example environment variable `KAFKA_BOOTSTRAP_SERVERS` will be used as the `bootstrap.servers` configuration option in the Kafka Consumer API.
 

--- a/java/kafka/deployment-oauth.yaml
+++ b/java/kafka/deployment-oauth.yaml
@@ -69,16 +69,20 @@ spec:
       - name: java-kafka-producer
         image: quay.io/strimzi-examples/java-kafka-producer:latest
         env:
-          - name: BOOTSTRAP_SERVERS
+          - name: KAFKA_BOOTSTRAP_SERVERS
             value: my-cluster-kafka-bootstrap:9092
-          - name: TOPIC
+          - name: STRIMZI_TOPIC
             value: my-topic
-          - name: DELAY_MS
+          - name: STRIMZI_DELAY_MS
             value: "1000"
-          - name: LOG_LEVEL
+          - name: STRIMZI_LOG_LEVEL
             value: "INFO"
-          - name: MESSAGE_COUNT
+          - name: STRIMZI_MESSAGE_COUNT
             value: "1000000"
+          - name: KAFKA_KEY_SERIALIZER
+            value: "org.apache.kafka.common.serialization.StringSerializer"
+          - name: KAFKA_VALUE_SERIALIZER
+            value: "org.apache.kafka.common.serialization.StringSerializer"
           - name: OAUTH_CLIENT_ID
             value: java-kafka-producer
           - name: OAUTH_CLIENT_SECRET

--- a/java/kafka/deployment-oauth.yaml
+++ b/java/kafka/deployment-oauth.yaml
@@ -18,29 +18,6 @@ spec:
   replicas: 3
   partitions: 12
 ---
-apiVersion: kafka.strimzi.io/v1beta1
-kind: KafkaUser
-metadata:
-  name: java-kafka-producer
-  labels:
-    strimzi.io/cluster: my-cluster
-spec:
-  authorization:
-    type: simple
-    acls:
-      - resource:
-          type: topic
-          name: my-topic
-        operation: Write
-      - resource:
-          type: topic
-          name: my-topic
-        operation: Create
-      - resource:
-          type: topic
-          name: my-topic
-        operation: Describe
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/java/kafka/deployment-oauth.yaml
+++ b/java/kafka/deployment-oauth.yaml
@@ -25,8 +25,6 @@ metadata:
   labels:
     strimzi.io/cluster: my-cluster
 spec:
-  authentication:
-    type: tls
   authorization:
     type: simple
     acls:
@@ -71,8 +69,6 @@ spec:
         - name: java-kafka-producer
           image: quay.io/strimzi-examples/java-kafka-producer:latest
           env:
-            - name: KAFKA_BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9093
             - name: STRIMZI_TOPIC
               value: my-topic
             - name: STRIMZI_DELAY_MS
@@ -81,10 +77,6 @@ spec:
               value: "INFO"
             - name: STRIMZI_MESSAGE_COUNT
               value: "1000000"
-            - name: KAFKA_KEY_SERIALIZER
-              value: "org.apache.kafka.common.serialization.StringSerializer"
-            - name: KAFKA_VALUE_SERIALIZER
-              value: "org.apache.kafka.common.serialization.StringSerializer"
             - name: OAUTH_CLIENT_ID
               value: java-kafka-producer
             - name: OAUTH_CLIENT_SECRET
@@ -101,6 +93,12 @@ spec:
                 secretKeyRef:
                   name: sso-x509-https-secret
                   key: tls.crt
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9093
+            - name: KAFKA_KEY_SERIALIZER
+              value: "org.apache.kafka.common.serialization.StringSerializer"
+            - name: KAFKA_VALUE_SERIALIZER
+              value: "org.apache.kafka.common.serialization.StringSerializer"
             - name: KAFKA_SECURITY_PROTOCOL
               value: "SASL_SSL"
             - name: KAFKA_SASL_JAAS_CONFIG

--- a/java/kafka/deployment-oauth.yaml
+++ b/java/kafka/deployment-oauth.yaml
@@ -90,7 +90,7 @@ spec:
             - name: OAUTH_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: java-kafka-producer
+                  name: java-kafka-producer-oauth
                   key: secret
             - name: OAUTH_TOKEN_ENDPOINT_URI
               value: https://sso.myproject.svc:8443/auth/realms/internal/protocol/openid-connect/token

--- a/java/kafka/deployment-oauth.yaml
+++ b/java/kafka/deployment-oauth.yaml
@@ -93,7 +93,7 @@ spec:
                   name: java-kafka-producer
                   key: secret
             - name: OAUTH_TOKEN_ENDPOINT_URI
-              value: https://keycloak:8443/auth/realms/kafka-authz/protocol/openid-connect/token
+              value: https://sso.myproject.svc:8443/auth/realms/internal/protocol/openid-connect/token
             - name: OAUTH_SSL_TRUSTSTORE_TYPE
               value: PEM
             - name: OAUTH_SSL_TRUSTSTORE_CERTIFICATES

--- a/java/kafka/deployment-oauth.yaml
+++ b/java/kafka/deployment-oauth.yaml
@@ -21,10 +21,12 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaUser
 metadata:
-  name: service-account-java-kafka-producer
+  name: java-kafka-producer
   labels:
     strimzi.io/cluster: my-cluster
 spec:
+  authentication:
+    type: tls
   authorization:
     type: simple
     acls:
@@ -66,39 +68,54 @@ spec:
         app: java-kafka-producer
     spec:
       containers:
-      - name: java-kafka-producer
-        image: quay.io/strimzi-examples/java-kafka-producer:latest
-        env:
-          - name: KAFKA_BOOTSTRAP_SERVERS
-            value: my-cluster-kafka-bootstrap:9092
-          - name: STRIMZI_TOPIC
-            value: my-topic
-          - name: STRIMZI_DELAY_MS
-            value: "1000"
-          - name: STRIMZI_LOG_LEVEL
-            value: "INFO"
-          - name: STRIMZI_MESSAGE_COUNT
-            value: "1000000"
-          - name: KAFKA_KEY_SERIALIZER
-            value: "org.apache.kafka.common.serialization.StringSerializer"
-          - name: KAFKA_VALUE_SERIALIZER
-            value: "org.apache.kafka.common.serialization.StringSerializer"
-          - name: OAUTH_CLIENT_ID
-            value: java-kafka-producer
-          - name: OAUTH_CLIENT_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: java-kafka-producer-oauth
-                key: clientSecret
-          - name: OAUTH_TOKEN_ENDPOINT_URI
-            value: https://sso.myproject.svc:8443/auth/realms/internal/protocol/openid-connect/token
-          - name: OAUTH_SSL_TRUSTSTORE_TYPE
-            value: PEM
-          - name: OAUTH_SSL_TRUSTSTORE_CERTIFICATES
-            valueFrom:
-              secretKeyRef:
-                name: sso-x509-https-secret
-                key: tls.crt
+        - name: java-kafka-producer
+          image: quay.io/strimzi-examples/java-kafka-producer:latest
+          env:
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9093
+            - name: STRIMZI_TOPIC
+              value: my-topic
+            - name: STRIMZI_DELAY_MS
+              value: "1000"
+            - name: STRIMZI_LOG_LEVEL
+              value: "INFO"
+            - name: STRIMZI_MESSAGE_COUNT
+              value: "1000000"
+            - name: KAFKA_KEY_SERIALIZER
+              value: "org.apache.kafka.common.serialization.StringSerializer"
+            - name: KAFKA_VALUE_SERIALIZER
+              value: "org.apache.kafka.common.serialization.StringSerializer"
+            - name: OAUTH_CLIENT_ID
+              value: java-kafka-producer
+            - name: OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: java-kafka-producer
+                  key: secret
+            - name: OAUTH_TOKEN_ENDPOINT_URI
+              value: https://keycloak:8443/auth/realms/kafka-authz/protocol/openid-connect/token
+            - name: OAUTH_SSL_TRUSTSTORE_TYPE
+              value: PEM
+            - name: OAUTH_SSL_TRUSTSTORE_CERTIFICATES
+              valueFrom:
+                secretKeyRef:
+                  name: sso-x509-https-secret
+                  key: tls.crt
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: "SASL_SSL"
+            - name: KAFKA_SASL_JAAS_CONFIG
+              value: "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;"
+            - name: KAFKA_SASL_MECHANISM
+              value: OAUTHBEARER
+            - name: KAFKA_SASL_LOGIN_CALLBACK_HANDLER_CLASS
+              value: "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
+            - name: KAFKA_SSL_TRUSTSTORE_TYPE
+              value: PEM
+            - name: KAFKA_SSL_TRUSTSTORE_CERTIFICATES
+              valueFrom:
+                secretKeyRef:
+                  name: my-cluster-cluster-ca-cert
+                  key: ca.crt
 ---
 apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaUser

--- a/java/kafka/deployment-ssl-auth.yaml
+++ b/java/kafka/deployment-ssl-auth.yaml
@@ -60,44 +60,44 @@ spec:
         app: java-kafka-producer
     spec:
       containers:
-      - name: java-kafka-producer
-        image: quay.io/strimzi-examples/java-kafka-producer:latest
-        env:
-          - name: KAFKA_SECURITY_PROTOCOL
-            value: SSL
-          - name: KAFKA_SSL_TRUSTSTORE_CERTIFICATES
-            valueFrom:
-              secretKeyRef:
-                name: my-cluster-cluster-ca-cert
-                key: ca.crt
-          - name: KAFKA_SSL_TRUSTSTORE_TYPE
-            value: PEM
-          - name: KAFKA_SSL_KEYSTORE_CERTIFICATE_CHAIN
-            valueFrom:
-              secretKeyRef:
-                name: java-kafka-producer
-                key: user.crt
-          - name: KAFKA_SSL_KEYSTORE_KEY
-            valueFrom:
-              secretKeyRef:
-                name: java-kafka-producer
-                key: user.key
-          - name: KAFKA_SSL_KEYSTORE_TYPE
-            value: PEM
-          - name: KAFKA_BOOTSTRAP_SERVERS
-            value: my-cluster-kafka-bootstrap:9093
-          - name: STRIMZI_TOPIC
-            value: my-topic
-          - name: STRIMZI_DELAY_MS
-            value: "1000"
-          - name: STRIMZI_LOG_LEVEL
-            value: "INFO"
-          - name: STRIMZI_MESSAGE_COUNT
-            value: "1000000"
-          - name: KAFKA_KEY_SERIALIZER
-            value: "org.apache.kafka.common.serialization.StringSerializer"
-          - name: KAFKA_VALUE_SERIALIZER
-            value: "org.apache.kafka.common.serialization.StringSerializer"
+        - name: java-kafka-producer
+          image: quay.io/strimzi-examples/java-kafka-producer:latest
+          env:
+            - name: STRIMZI_TOPIC
+              value: my-topic
+            - name: STRIMZI_DELAY_MS
+              value: "1000"
+            - name: STRIMZI_LOG_LEVEL
+              value: "INFO"
+            - name: STRIMZI_MESSAGE_COUNT
+              value: "1000000"
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9093
+            - name: KAFKA_KEY_SERIALIZER
+              value: "org.apache.kafka.common.serialization.StringSerializer"
+            - name: KAFKA_VALUE_SERIALIZER
+              value: "org.apache.kafka.common.serialization.StringSerializer"
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: SSL
+            - name: KAFKA_SSL_TRUSTSTORE_CERTIFICATES
+              valueFrom:
+                secretKeyRef:
+                  name: my-cluster-cluster-ca-cert
+                  key: ca.crt
+            - name: KAFKA_SSL_TRUSTSTORE_TYPE
+              value: PEM
+            - name: KAFKA_SSL_KEYSTORE_CERTIFICATE_CHAIN
+              valueFrom:
+                secretKeyRef:
+                  name: java-kafka-producer
+                  key: user.crt
+            - name: KAFKA_SSL_KEYSTORE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: java-kafka-producer
+                  key: user.key
+            - name: KAFKA_SSL_KEYSTORE_TYPE
+              value: PEM
 ---
 apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaUser

--- a/java/kafka/deployment-ssl-auth.yaml
+++ b/java/kafka/deployment-ssl-auth.yaml
@@ -63,31 +63,41 @@ spec:
       - name: java-kafka-producer
         image: quay.io/strimzi-examples/java-kafka-producer:latest
         env:
-          - name: CA_CRT
+          - name: KAFKA_SECURITY_PROTOCOL
+            value: SSL
+          - name: KAFKA_SSL_TRUSTSTORE_CERTIFICATES
             valueFrom:
               secretKeyRef:
                 name: my-cluster-cluster-ca-cert
                 key: ca.crt
-          - name: USER_CRT
+          - name: KAFKA_SSL_TRUSTSTORE_TYPE
+            value: PEM
+          - name: KAFKA_SSL_KEYSTORE_CERTIFICATE_CHAIN
             valueFrom:
               secretKeyRef:
                 name: java-kafka-producer
                 key: user.crt
-          - name: USER_KEY
+          - name: KAFKA_SSL_KEYSTORE_KEY
             valueFrom:
               secretKeyRef:
                 name: java-kafka-producer
                 key: user.key
-          - name: BOOTSTRAP_SERVERS
+          - name: KAFKA_SSL_KEYSTORE_TYPE
+            value: PEM
+          - name: KAFKA_BOOTSTRAP_SERVERS
             value: my-cluster-kafka-bootstrap:9093
-          - name: TOPIC
+          - name: STRIMZI_TOPIC
             value: my-topic
-          - name: DELAY_MS
+          - name: STRIMZI_DELAY_MS
             value: "1000"
-          - name: LOG_LEVEL
+          - name: STRIMZI_LOG_LEVEL
             value: "INFO"
-          - name: MESSAGE_COUNT
+          - name: STRIMZI_MESSAGE_COUNT
             value: "1000000"
+          - name: KAFKA_KEY_SERIALIZER
+            value: "org.apache.kafka.common.serialization.StringSerializer"
+          - name: KAFKA_VALUE_SERIALIZER
+            value: "org.apache.kafka.common.serialization.StringSerializer"
 ---
 apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaUser

--- a/java/kafka/deployment-ssl.yaml
+++ b/java/kafka/deployment-ssl.yaml
@@ -38,21 +38,29 @@ spec:
       - name: java-kafka-producer
         image: quay.io/strimzi-examples/java-kafka-producer:latest
         env:
-          - name: CA_CRT
+          - name: KAFKA_SSL_TRUSTSTORE_CERTIFICATES
             valueFrom:
               secretKeyRef:
                 name: my-cluster-cluster-ca-cert
                 key: ca.crt
-          - name: BOOTSTRAP_SERVERS
+          - name: KAFKA_SECURITY_PROTOCOL
+            value: SSL
+          - name: KAFKA_SSL_TRUSTSTORE_TYPE
+            value: PEM
+          - name: KAFKA_BOOTSTRAP_SERVERS
             value: my-cluster-kafka-bootstrap:9093
-          - name: TOPIC
+          - name: STRIMZI_TOPIC
             value: my-topic
-          - name: DELAY_MS
+          - name: STRIMZI_DELAY_MS
             value: "1000"
-          - name: LOG_LEVEL
+          - name: STRIMZI_LOG_LEVEL
             value: "INFO"
-          - name: MESSAGE_COUNT
+          - name: STRIMZI_MESSAGE_COUNT
             value: "1000000"
+          - name: KAFKA_KEY_SERIALIZER
+            value: "org.apache.kafka.common.serialization.StringSerializer"
+          - name: KAFKA_VALUE_SERIALIZER
+            value: "org.apache.kafka.common.serialization.StringSerializer"
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/java/kafka/deployment-ssl.yaml
+++ b/java/kafka/deployment-ssl.yaml
@@ -35,32 +35,33 @@ spec:
         app: java-kafka-producer
     spec:
       containers:
-      - name: java-kafka-producer
-        image: quay.io/strimzi-examples/java-kafka-producer:latest
-        env:
-          - name: KAFKA_SSL_TRUSTSTORE_CERTIFICATES
-            valueFrom:
-              secretKeyRef:
-                name: my-cluster-cluster-ca-cert
-                key: ca.crt
-          - name: KAFKA_SECURITY_PROTOCOL
-            value: SSL
-          - name: KAFKA_SSL_TRUSTSTORE_TYPE
-            value: PEM
-          - name: KAFKA_BOOTSTRAP_SERVERS
-            value: my-cluster-kafka-bootstrap:9093
-          - name: STRIMZI_TOPIC
-            value: my-topic
-          - name: STRIMZI_DELAY_MS
-            value: "1000"
-          - name: STRIMZI_LOG_LEVEL
-            value: "INFO"
-          - name: STRIMZI_MESSAGE_COUNT
-            value: "1000000"
-          - name: KAFKA_KEY_SERIALIZER
-            value: "org.apache.kafka.common.serialization.StringSerializer"
-          - name: KAFKA_VALUE_SERIALIZER
-            value: "org.apache.kafka.common.serialization.StringSerializer"
+        - name: java-kafka-producer
+          image: quay.io/strimzi-examples/java-kafka-producer:latest
+          env:
+            - name: STRIMZI_TOPIC
+              value: my-topic
+            - name: STRIMZI_DELAY_MS
+              value: "1000"
+            - name: STRIMZI_LOG_LEVEL
+              value: "INFO"
+            - name: STRIMZI_MESSAGE_COUNT
+              value: "1000000"
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9093
+            - name: KAFKA_KEY_SERIALIZER
+              value: "org.apache.kafka.common.serialization.StringSerializer"
+            - name: KAFKA_VALUE_SERIALIZER
+              value: "org.apache.kafka.common.serialization.StringSerializer"
+            - name: KAFKA_SSL_TRUSTSTORE_CERTIFICATES
+              valueFrom:
+                secretKeyRef:
+                  name: my-cluster-cluster-ca-cert
+                  key: ca.crt
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: SSL
+            - name: KAFKA_SSL_TRUSTSTORE_TYPE
+              value: PEM
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -115,29 +116,29 @@ spec:
         app: java-kafka-consumer
     spec:
       containers:
-      - name: java-kafka-consumer
-        image: quay.io/strimzi-examples/java-kafka-consumer:latest
-        env:
-          - name: KAFKA_SSL_TRUSTSTORE_CERTIFICATES
-            valueFrom:
-              secretKeyRef:
-                name: my-cluster-cluster-ca-cert
-                key: ca.crt
-          - name: KAFKA_SECURITY_PROTOCOL
-            value: SSL
-          - name: KAFKA_SSL_TRUSTSTORE_TYPE
-            value: PEM
-          - name: KAFKA_BOOTSTRAP_SERVERS
-            value: my-cluster-kafka-bootstrap:9093
-          - name: STRIMZI_TOPIC
-            value: my-topic-reversed
-          - name: KAFKA_GROUP_ID
-            value: java-kafka-consumer
-          - name: STRIMZI_LOG_LEVEL
-            value: "INFO"
-          - name: STRIMZI_MESSAGE_COUNT
-            value: "1000000"
-          - name: KAFKA_KEY_DESERIALIZER
-            value: "org.apache.kafka.common.serialization.StringDeserializer"
-          - name: KAFKA_VALUE_DESERIALIZER
-            value: "org.apache.kafka.common.serialization.StringDeserializer"
+        - name: java-kafka-consumer
+          image: quay.io/strimzi-examples/java-kafka-consumer:latest
+          env:
+            - name: KAFKA_SSL_TRUSTSTORE_CERTIFICATES
+              valueFrom:
+                secretKeyRef:
+                  name: my-cluster-cluster-ca-cert
+                  key: ca.crt
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: SSL
+            - name: KAFKA_SSL_TRUSTSTORE_TYPE
+              value: PEM
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9093
+            - name: STRIMZI_TOPIC
+              value: my-topic-reversed
+            - name: KAFKA_GROUP_ID
+              value: java-kafka-consumer
+            - name: STRIMZI_LOG_LEVEL
+              value: "INFO"
+            - name: STRIMZI_MESSAGE_COUNT
+              value: "1000000"
+            - name: KAFKA_KEY_DESERIALIZER
+              value: "org.apache.kafka.common.serialization.StringDeserializer"
+            - name: KAFKA_VALUE_DESERIALIZER
+              value: "org.apache.kafka.common.serialization.StringDeserializer"

--- a/java/kafka/deployment-tracing-jaeger.yaml
+++ b/java/kafka/deployment-tracing-jaeger.yaml
@@ -38,16 +38,20 @@ spec:
       - name: java-kafka-producer
         image: quay.io/strimzi-examples/java-kafka-producer:latest
         env:
-          - name: BOOTSTRAP_SERVERS
+          - name: KAFKA_BOOTSTRAP_SERVERS
             value: my-cluster-kafka-bootstrap:9092
-          - name: TOPIC
+          - name: STRIMZI_TOPIC
             value: my-topic
-          - name: DELAY_MS
+          - name: STRIMZI_DELAY_MS
             value: "1000"
-          - name: LOG_LEVEL
+          - name: STRIMZI_LOG_LEVEL
             value: "INFO"
-          - name: MESSAGE_COUNT
+          - name: STRIMZI_MESSAGE_COUNT
             value: "1000000"
+          - name: KAFKA_KEY_SERIALIZER
+            value: "org.apache.kafka.common.serialization.StringSerializer"
+          - name: KAFKA_VALUE_SERIALIZER
+            value: "org.apache.kafka.common.serialization.StringSerializer"
           - name: JAEGER_SERVICE_NAME
             value: java-kafka-producer
           - name: JAEGER_AGENT_HOST

--- a/java/kafka/deployment-tracing-jaeger.yaml
+++ b/java/kafka/deployment-tracing-jaeger.yaml
@@ -60,7 +60,7 @@ spec:
             value: const
           - name: JAEGER_SAMPLER_PARAM
             value: "1"
-          - name: TRACING_SYSTEM
+          - name: STRIMZI_TRACING_SYSTEM
             value: jaeger
 ---
 apiVersion: apps/v1
@@ -101,7 +101,7 @@ spec:
               value: const
             - name: JAEGER_SAMPLER_PARAM
               value: "1"
-            - name: TRACING_SYSTEM
+            - name: STRIMZI_TRACING_SYSTEM
               value: jaeger
             - name: KAFKA_KEY_DESERIALIZER
               value: "org.apache.kafka.common.serialization.StringDeserializer"

--- a/java/kafka/deployment-tracing-jaeger.yaml
+++ b/java/kafka/deployment-tracing-jaeger.yaml
@@ -35,33 +35,33 @@ spec:
         app: java-kafka-producer
     spec:
       containers:
-      - name: java-kafka-producer
-        image: quay.io/strimzi-examples/java-kafka-producer:latest
-        env:
-          - name: KAFKA_BOOTSTRAP_SERVERS
-            value: my-cluster-kafka-bootstrap:9092
-          - name: STRIMZI_TOPIC
-            value: my-topic
-          - name: STRIMZI_DELAY_MS
-            value: "1000"
-          - name: STRIMZI_LOG_LEVEL
-            value: "INFO"
-          - name: STRIMZI_MESSAGE_COUNT
-            value: "1000000"
-          - name: KAFKA_KEY_SERIALIZER
-            value: "org.apache.kafka.common.serialization.StringSerializer"
-          - name: KAFKA_VALUE_SERIALIZER
-            value: "org.apache.kafka.common.serialization.StringSerializer"
-          - name: JAEGER_SERVICE_NAME
-            value: java-kafka-producer
-          - name: JAEGER_AGENT_HOST
-            value: my-jaeger-agent
-          - name: JAEGER_SAMPLER_TYPE
-            value: const
-          - name: JAEGER_SAMPLER_PARAM
-            value: "1"
-          - name: STRIMZI_TRACING_SYSTEM
-            value: jaeger
+        - name: java-kafka-producer
+          image: quay.io/strimzi-examples/java-kafka-producer:latest
+          env:
+            - name: STRIMZI_TOPIC
+              value: my-topic
+            - name: STRIMZI_DELAY_MS
+              value: "1000"
+            - name: STRIMZI_LOG_LEVEL
+              value: "INFO"
+            - name: STRIMZI_MESSAGE_COUNT
+              value: "1000000"
+            - name: STRIMZI_TRACING_SYSTEM
+              value: jaeger
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9092
+            - name: KAFKA_KEY_SERIALIZER
+              value: "org.apache.kafka.common.serialization.StringSerializer"
+            - name: KAFKA_VALUE_SERIALIZER
+              value: "org.apache.kafka.common.serialization.StringSerializer"
+            - name: JAEGER_SERVICE_NAME
+              value: java-kafka-producer
+            - name: JAEGER_AGENT_HOST
+              value: my-jaeger-agent
+            - name: JAEGER_SAMPLER_TYPE
+              value: const
+            - name: JAEGER_SAMPLER_PARAM
+              value: "1"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -83,16 +83,22 @@ spec:
         - name: java-kafka-consumer
           image: quay.io/strimzi-examples/java-kafka-consumer:latest
           env:
-            - name: KAFKA_BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9092
-            - name: STRIMZI_TOPIC
-              value: my-topic-reversed
-            - name: KAFKA_GROUP_ID
-              value: java-kafka-consumer
             - name: STRIMZI_LOG_LEVEL
               value: "INFO"
             - name: STRIMZI_MESSAGE_COUNT
               value: "1000000"
+            - name: STRIMZI_TOPIC
+              value: my-topic-reversed
+            - name: STRIMZI_TRACING_SYSTEM
+              value: jaeger
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9092
+            - name: KAFKA_GROUP_ID
+              value: java-kafka-consumer
+            - name: KAFKA_KEY_DESERIALIZER
+              value: "org.apache.kafka.common.serialization.StringDeserializer"
+            - name: KAFKA_VALUE_DESERIALIZER
+              value: "org.apache.kafka.common.serialization.StringDeserializer"
             - name: JAEGER_SERVICE_NAME
               value: java-kafka-consumer
             - name: JAEGER_AGENT_HOST
@@ -101,9 +107,3 @@ spec:
               value: const
             - name: JAEGER_SAMPLER_PARAM
               value: "1"
-            - name: STRIMZI_TRACING_SYSTEM
-              value: jaeger
-            - name: KAFKA_KEY_DESERIALIZER
-              value: "org.apache.kafka.common.serialization.StringDeserializer"
-            - name: KAFKA_VALUE_DESERIALIZER
-              value: "org.apache.kafka.common.serialization.StringDeserializer"

--- a/java/kafka/deployment-tracing-opentelemetry.yaml
+++ b/java/kafka/deployment-tracing-opentelemetry.yaml
@@ -60,7 +60,7 @@ spec:
               value: none
             - name: OTEL_EXPORTER_JAEGER_ENDPOINT
               value: http://my-jaeger-collector:14250
-            - name: TRACING_SYSTEM
+            - name: STRIMZI_TRACING_SYSTEM
               value: opentelemetry
 ---
 apiVersion: apps/v1
@@ -146,5 +146,5 @@ spec:
               value: none
             - name: OTEL_EXPORTER_JAEGER_ENDPOINT
               value: http://my-jaeger-collector:14250
-            - name: TRACING_SYSTEM
+            - name: STRIMZI_TRACING_SYSTEM
               value: opentelemetry

--- a/java/kafka/deployment-tracing-opentelemetry.yaml
+++ b/java/kafka/deployment-tracing-opentelemetry.yaml
@@ -38,8 +38,6 @@ spec:
         - name: java-kafka-producer
           image: quay.io/strimzi-examples/java-kafka-producer:latest
           env:
-            - name: KAFKA_BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9092
             - name: STRIMZI_TOPIC
               value: my-topic
             - name: STRIMZI_DELAY_MS
@@ -48,6 +46,10 @@ spec:
               value: "INFO"
             - name: STRIMZI_MESSAGE_COUNT
               value: "1000000"
+            - name: STRIMZI_TRACING_SYSTEM
+              value: opentelemetry
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9092
             - name: KAFKA_KEY_SERIALIZER
               value: "org.apache.kafka.common.serialization.StringSerializer"
             - name: KAFKA_VALUE_SERIALIZER
@@ -60,8 +62,6 @@ spec:
               value: none
             - name: OTEL_EXPORTER_JAEGER_ENDPOINT
               value: http://my-jaeger-collector:14250
-            - name: STRIMZI_TRACING_SYSTEM
-              value: opentelemetry
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/java/kafka/deployment-tracing-opentelemetry.yaml
+++ b/java/kafka/deployment-tracing-opentelemetry.yaml
@@ -38,16 +38,20 @@ spec:
         - name: java-kafka-producer
           image: quay.io/strimzi-examples/java-kafka-producer:latest
           env:
-            - name: BOOTSTRAP_SERVERS
+            - name: KAFKA_BOOTSTRAP_SERVERS
               value: my-cluster-kafka-bootstrap:9092
-            - name: TOPIC
+            - name: STRIMZI_TOPIC
               value: my-topic
-            - name: DELAY_MS
+            - name: STRIMZI_DELAY_MS
               value: "1000"
-            - name: LOG_LEVEL
+            - name: STRIMZI_LOG_LEVEL
               value: "INFO"
-            - name: MESSAGE_COUNT
+            - name: STRIMZI_MESSAGE_COUNT
               value: "1000000"
+            - name: KAFKA_KEY_SERIALIZER
+              value: "org.apache.kafka.common.serialization.StringSerializer"
+            - name: KAFKA_VALUE_SERIALIZER
+              value: "org.apache.kafka.common.serialization.StringSerializer"
             - name: OTEL_SERVICE_NAME
               value: kafka-otel
             - name: OTEL_TRACES_EXPORTER

--- a/java/kafka/deployment.yaml
+++ b/java/kafka/deployment.yaml
@@ -38,16 +38,20 @@ spec:
       - name: java-kafka-producer
         image: quay.io/strimzi-examples/java-kafka-producer:latest
         env:
-          - name: BOOTSTRAP_SERVERS
+          - name: KAFKA_BOOTSTRAP_SERVERS
             value: my-cluster-kafka-bootstrap:9092
-          - name: TOPIC
+          - name: STRIMZI_TOPIC
             value: my-topic
-          - name: DELAY_MS
+          - name: STRIMZI_DELAY_MS
             value: "1000"
-          - name: LOG_LEVEL
+          - name: STRIMZI_LOG_LEVEL
             value: "INFO"
-          - name: MESSAGE_COUNT
+          - name: STRIMZI_MESSAGE_COUNT
             value: "1000000"
+          - name: KAFKA_KEY_SERIALIZER
+            value: "org.apache.kafka.common.serialization.StringSerializer"
+          - name: KAFKA_VALUE_SERIALIZER
+            value: "org.apache.kafka.common.serialization.StringSerializer"
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/java/kafka/deployment.yaml
+++ b/java/kafka/deployment.yaml
@@ -35,23 +35,23 @@ spec:
         app: java-kafka-producer
     spec:
       containers:
-      - name: java-kafka-producer
-        image: quay.io/strimzi-examples/java-kafka-producer:latest
-        env:
-          - name: KAFKA_BOOTSTRAP_SERVERS
-            value: my-cluster-kafka-bootstrap:9092
-          - name: STRIMZI_TOPIC
-            value: my-topic
-          - name: STRIMZI_DELAY_MS
-            value: "1000"
-          - name: STRIMZI_LOG_LEVEL
-            value: "INFO"
-          - name: STRIMZI_MESSAGE_COUNT
-            value: "1000000"
-          - name: KAFKA_KEY_SERIALIZER
-            value: "org.apache.kafka.common.serialization.StringSerializer"
-          - name: KAFKA_VALUE_SERIALIZER
-            value: "org.apache.kafka.common.serialization.StringSerializer"
+        - name: java-kafka-producer
+          image: quay.io/strimzi-examples/java-kafka-producer:latest
+          env:
+            - name: STRIMZI_TOPIC
+              value: my-topic
+            - name: STRIMZI_DELAY_MS
+              value: "1000"
+            - name: STRIMZI_LOG_LEVEL
+              value: "INFO"
+            - name: STRIMZI_MESSAGE_COUNT
+              value: "1000000"
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9092
+            - name: KAFKA_KEY_SERIALIZER
+              value: "org.apache.kafka.common.serialization.StringSerializer"
+            - name: KAFKA_VALUE_SERIALIZER
+              value: "org.apache.kafka.common.serialization.StringSerializer"
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/java/kafka/java-kafka-producer.yaml
+++ b/java/kafka/java-kafka-producer.yaml
@@ -15,23 +15,22 @@ spec:
         app: java-kafka-producer
     spec:
       containers:
-      - name: java-kafka-producer
-        image: quay.io/strimzi-examples/java-kafka-producer:latest
-        env:
-          - name: KAFKA_BOOTSTRAP_SERVERS
-            value: my-cluster-kafka-bootstrap:9092
-          - name: STRIMZI_TOPIC
-            value: my-topic
-          - name: STRIMZI_DELAY_MS
-            value: "1000"
-          - name: STRIMZI_LOG_LEVEL
-            value: "INFO"
-          - name: STRIMZI_MESSAGE_COUNT
-            value: "1000000"
-          - name: KAFKA_ACKS
-            value: "all"
-          - name: KAFKA_KEY_SERIALIZER
-            value: "org.apache.kafka.common.serialization.StringSerializer"
-          - name: KAFKA_VALUE_SERIALIZER
-            value: "org.apache.kafka.common.serialization.StringSerializer"
-           
+        - name: java-kafka-producer
+          image: quay.io/strimzi-examples/java-kafka-producer:latest
+          env:
+            - name: STRIMZI_TOPIC
+              value: my-topic
+            - name: STRIMZI_DELAY_MS
+              value: "1000"
+            - name: STRIMZI_LOG_LEVEL
+              value: "INFO"
+            - name: STRIMZI_MESSAGE_COUNT
+              value: "1000000"
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9092
+            - name: KAFKA_ACKS
+              value: "all"
+            - name: KAFKA_KEY_SERIALIZER
+              value: "org.apache.kafka.common.serialization.StringSerializer"
+            - name: KAFKA_VALUE_SERIALIZER
+              value: "org.apache.kafka.common.serialization.StringSerializer"

--- a/java/kafka/java-kafka-producer.yaml
+++ b/java/kafka/java-kafka-producer.yaml
@@ -18,18 +18,20 @@ spec:
       - name: java-kafka-producer
         image: quay.io/strimzi-examples/java-kafka-producer:latest
         env:
-          - name: BOOTSTRAP_SERVERS
+          - name: KAFKA_BOOTSTRAP_SERVERS
             value: my-cluster-kafka-bootstrap:9092
-          - name: TOPIC
+          - name: STRIMZI_TOPIC
             value: my-topic
-          - name: DELAY_MS
+          - name: STRIMZI_DELAY_MS
             value: "1000"
-          - name: LOG_LEVEL
+          - name: STRIMZI_LOG_LEVEL
             value: "INFO"
-          - name: MESSAGE_COUNT
+          - name: STRIMZI_MESSAGE_COUNT
             value: "1000000"
-          - name: PRODUCER_ACKS
+          - name: STRIMZI_PRODUCER_ACKS
             value: "all"
-          - name: ADDITIONAL_CONFIG
-            value: |
-              retries=100
+          - name: KAFKA_KEY_SERIALIZER
+            value: "org.apache.kafka.common.serialization.StringSerializer"
+          - name: KAFKA_VALUE_SERIALIZER
+            value: "org.apache.kafka.common.serialization.StringSerializer"
+           

--- a/java/kafka/java-kafka-producer.yaml
+++ b/java/kafka/java-kafka-producer.yaml
@@ -28,7 +28,7 @@ spec:
             value: "INFO"
           - name: STRIMZI_MESSAGE_COUNT
             value: "1000000"
-          - name: STRIMZI_PRODUCER_ACKS
+          - name: KAFKA_ACKS
             value: "all"
           - name: KAFKA_KEY_SERIALIZER
             value: "org.apache.kafka.common.serialization.StringSerializer"

--- a/java/kafka/producer/src/main/java/KafkaProducerConfig.java
+++ b/java/kafka/producer/src/main/java/KafkaProducerConfig.java
@@ -3,230 +3,94 @@
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 
-import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.config.SaslConfigs;
-import org.apache.kafka.common.config.SslConfigs;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
+import java.util.Map;
 import java.util.Properties;
-import java.util.StringTokenizer;
+import java.util.stream.Collectors;
 
 public class KafkaProducerConfig {
-    private static final Logger log = LogManager.getLogger(KafkaProducerConfig.class);
 
     private static final long DEFAULT_MESSAGES_COUNT = 10;
     private static final String DEFAULT_MESSAGE = "Hello world";
-    private final String bootstrapServers;
-    private final String topic;
-    private final int delay;
-    private final Long messageCount;
-    private final String message;
-    private final String acks;
-    private final String headers;
-    private final String sslTruststoreCertificates;
-    private final String sslKeystoreKey;
-    private final String sslKeystoreCertificateChain;
-    private final String oauthClientId;
-    private final String oauthClientSecret;
-    private final String oauthAccessToken;
-    private final String oauthRefreshToken;
-    private final String oauthTokenEndpointUri;
-    private final String additionalConfig;
-    private final String saslLoginCallbackClass = "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler";
-    private final TracingSystem tracingSystem;
+    private static final String KAFKA_PREFIX = "KAFKA_";
 
-    public KafkaProducerConfig(String bootstrapServers, String topic, int delay, Long messageCount, String message,
-                               String sslTruststoreCertificates, String sslKeystoreKey, String sslKeystoreCertificateChain,
-                               String oauthClientId, String oauthClientSecret, String oauthAccessToken, String oauthRefreshToken,
-                               String oauthTokenEndpointUri, String acks, String additionalConfig, String headers, TracingSystem tracingSystem) {
-        this.bootstrapServers = bootstrapServers;
+    private final String topic;
+    private final Long messageCount;
+    private final int delay;
+    private final String message;
+    private final String headers;
+    private final TracingSystem tracingSystem;
+    private final Properties properties;
+
+    public KafkaProducerConfig(String topic, Long messageCount, int delay, String message,
+                               String headers, TracingSystem tracingSystem, Properties properties) {
+
         this.topic = topic;
-        this.delay = delay;
         this.messageCount = messageCount;
+        this.delay = delay;
         this.message = message;
-        this.sslTruststoreCertificates = sslTruststoreCertificates;
-        this.sslKeystoreKey = sslKeystoreKey;
-        this.sslKeystoreCertificateChain = sslKeystoreCertificateChain;
-        this.oauthClientId = oauthClientId;
-        this.oauthClientSecret = oauthClientSecret;
-        this.oauthAccessToken = oauthAccessToken;
-        this.oauthRefreshToken = oauthRefreshToken;
-        this.oauthTokenEndpointUri = oauthTokenEndpointUri;
-        this.acks = acks;
         this.headers = headers;
-        this.additionalConfig = additionalConfig;
         this.tracingSystem = tracingSystem;
+        this.properties = properties;
     }
 
     public static KafkaProducerConfig fromEnv() {
-        String bootstrapServers = System.getenv("BOOTSTRAP_SERVERS");
-        String topic = System.getenv("TOPIC");
-        int delay = Integer.parseInt(System.getenv("DELAY_MS"));
-        Long messageCount = System.getenv("MESSAGE_COUNT") == null ? DEFAULT_MESSAGES_COUNT : Long.parseLong(System.getenv("MESSAGE_COUNT"));
-        String message = System.getenv("MESSAGE") == null ? DEFAULT_MESSAGE : System.getenv("MESSAGE");
-        String sslTruststoreCertificates = System.getenv("CA_CRT");
-        String sslKeystoreKey = System.getenv("USER_KEY");
-        String sslKeystoreCertificateChain = System.getenv("USER_CRT");
-        String oauthClientId = System.getenv("OAUTH_CLIENT_ID");
-        String oauthClientSecret = System.getenv("OAUTH_CLIENT_SECRET");
-        String oauthAccessToken = System.getenv("OAUTH_ACCESS_TOKEN");
-        String oauthRefreshToken = System.getenv("OAUTH_REFRESH_TOKEN");
-        String oauthTokenEndpointUri = System.getenv("OAUTH_TOKEN_ENDPOINT_URI");
-        String acks = System.getenv().getOrDefault("PRODUCER_ACKS", "1");
-        String headers = System.getenv("HEADERS");
-        String additionalConfig = System.getenv().getOrDefault("ADDITIONAL_CONFIG", "");
-        TracingSystem tracingSystem = TracingSystem.forValue(System.getenv().getOrDefault("TRACING_SYSTEM", ""));
-
-        return new KafkaProducerConfig(bootstrapServers, topic, delay, messageCount, message, sslTruststoreCertificates,
-                sslKeystoreKey, sslKeystoreCertificateChain, oauthClientId, oauthClientSecret, oauthAccessToken, oauthRefreshToken,
-                oauthTokenEndpointUri, acks, additionalConfig, headers, tracingSystem);
+        String topic = System.getenv("STRIMZI_TOPIC");
+        Long messageCount = System.getenv("STRIMZI_MESSAGE_COUNT") == null ? DEFAULT_MESSAGES_COUNT : Long.parseLong(System.getenv("STRIMZI_MESSAGE_COUNT"));
+        int delay = Integer.parseInt(System.getenv("STRIMZI_DELAY_MS"));
+        String message = System.getenv("STRIMZI_MESSAGE") == null ? DEFAULT_MESSAGE : System.getenv("STRIMZI_MESSAGE");
+        String headers = System.getenv("STRIMZI_HEADERS");
+        TracingSystem tracingSystem = TracingSystem.forValue(System.getenv().getOrDefault("STRIMZI_TRACING_SYSTEM", ""));
+        Properties properties = new Properties();
+        properties.putAll(System.getenv()
+                .entrySet()
+                .stream()
+                .filter(mapEntry -> mapEntry.getKey().startsWith(KAFKA_PREFIX))
+                .collect(Collectors.toMap(mapEntry -> convertEnvVarToPropertyKey(mapEntry.getKey()), Map.Entry::getValue)));
+        return new KafkaProducerConfig(topic, messageCount, delay, message, headers, tracingSystem, properties);
     }
 
-    public static Properties createProperties(KafkaProducerConfig config) {
-        Properties props = new Properties();
-        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBootstrapServers());
-        props.put(ProducerConfig.ACKS_CONFIG, config.getAcks());
-        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
-        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
-
-        if (config.getSslTruststoreCertificates() != null)   {
-            log.info("Configuring truststore");
-            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
-            props.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PEM");
-            props.put(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, config.getSslTruststoreCertificates());
-        }
-
-        if (config.getSslKeystoreCertificateChain() != null && config.getSslKeystoreKey() != null)   {
-            log.info("Configuring keystore");
-            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
-            props.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PEM");
-            props.put(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, config.getSslKeystoreCertificateChain());
-            props.put(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, config.getSslKeystoreKey());
-        }
-
-        Properties additionalProps = new Properties();
-        if (!config.getAdditionalConfig().isEmpty()) {
-            StringTokenizer tok = new StringTokenizer(config.getAdditionalConfig(), System.lineSeparator());
-            while (tok.hasMoreTokens()) {
-                String record = tok.nextToken();
-                int endIndex = record.indexOf('=');
-                if (endIndex == -1) {
-                    throw new RuntimeException("Failed to parse Map from String");
-                }
-                String key = record.substring(0, endIndex);
-                String value = record.substring(endIndex + 1);
-                additionalProps.put(key.trim(), value.trim());
-            }
-        }
-
-        if ((config.getOauthAccessToken() != null)
-                || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthRefreshToken() != null)
-                || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthClientSecret() != null))    {
-            log.info("Configuring OAuth");
-            props.put(SaslConfigs.SASL_JAAS_CONFIG, "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;");
-            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL".equals(props.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)) ? "SASL_SSL" : "SASL_PLAINTEXT");
-            props.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
-            if (!(additionalProps.containsKey(SaslConfigs.SASL_MECHANISM) && additionalProps.getProperty(SaslConfigs.SASL_MECHANISM).equals("PLAIN"))) {
-                props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, config.saslLoginCallbackClass);
-            }
-        }
-
-        // override properties with defined additional properties
-        props.putAll(additionalProps);
-
-        return props;
-    }
-
-    public String getBootstrapServers() {
-        return bootstrapServers;
+    private static String convertEnvVarToPropertyKey(String envVar) {
+        return envVar.substring(envVar.indexOf("_") + 1).toLowerCase().replace("_", ".");
     }
 
     public String getTopic() {
         return topic;
     }
 
-    public int getDelay() {
-        return delay;
-    }
-
     public Long getMessageCount() {
         return messageCount;
+    }
+
+    public int getDelay() {
+        return delay;
     }
 
     public String getMessage() {
         return message;
     }
 
-    public String getAcks() {
-        return acks;
-    }
-
-    public String getSslTruststoreCertificates() {
-        return sslTruststoreCertificates;
-    }
-
-    public String getSslKeystoreKey() {
-        return sslKeystoreKey;
-    }
-
-    public String getSslKeystoreCertificateChain() {
-        return sslKeystoreCertificateChain;
-    }
-
-    public String getOauthClientId() {
-        return oauthClientId;
-    }
-
-    public String getOauthClientSecret() {
-        return oauthClientSecret;
-    }
-
-    public String getOauthAccessToken() {
-        return oauthAccessToken;
-    }
-
-    public String getOauthRefreshToken() {
-        return oauthRefreshToken;
-    }
-
-    public String getOauthTokenEndpointUri() {
-        return oauthTokenEndpointUri;
-    }
-
     public String getHeaders() {
         return headers;
-    }
-
-    public String getAdditionalConfig() {
-        return additionalConfig;
     }
 
     public TracingSystem getTracingSystem() {
         return tracingSystem;
     }
 
+    public Properties getProperties() {
+        return properties;
+    }
+
     @Override
     public String toString() {
         return "KafkaProducerConfig{" +
-            "bootstrapServers='" + bootstrapServers + '\'' +
             ", topic='" + topic + '\'' +
-            ", delay=" + delay +
             ", messageCount=" + messageCount +
-            ", message='" + message + '\'' +
-            ", acks='" + acks + '\'' +
-            ", headers='" + headers + '\'' +
-            ", sslTruststoreCertificates='" + sslTruststoreCertificates + '\'' +
-            ", sslKeystoreKey='" + sslKeystoreKey + '\'' +
-            ", sslKeystoreCertificateChain='" + sslKeystoreCertificateChain + '\'' +
-            ", oauthClientId='" + oauthClientId + '\'' +
-            ", oauthClientSecret='" + oauthClientSecret + '\'' +
-            ", oauthAccessToken='" + oauthAccessToken + '\'' +
-            ", oauthRefreshToken='" + oauthRefreshToken + '\'' +
-            ", oauthTokenEndpointUri='" + oauthTokenEndpointUri + '\'' +
-            ", additionalConfig='" + additionalConfig + '\'' +
+            ", delay=" + delay +
+            ", message=" + message +
+            ", headers=" + headers +
             ", tracingSystem='" + tracingSystem + '\'' +
+            ", properties ='" + properties + '\'' +
             '}';
     }
 }

--- a/java/kafka/producer/src/main/java/KafkaProducerExample.java
+++ b/java/kafka/producer/src/main/java/KafkaProducerExample.java
@@ -19,8 +19,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.apache.kafka.clients.producer.ProducerConfig.TRANSACTIONAL_ID_CONFIG;
-
 public class KafkaProducerExample {
     private static final Logger log = LogManager.getLogger(KafkaProducerExample.class);
 
@@ -43,7 +41,7 @@ public class KafkaProducerExample {
 
                 props.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, io.opentelemetry.instrumentation.kafkaclients.TracingProducerInterceptor.class.getName());
             } else {
-                log.error("Error: TRACING_SYSTEM {} is not recognized or supported!", config.getTracingSystem());
+                log.error("Error: STRIMZI_TRACING_SYSTEM {} is not recognized or supported!", config.getTracingSystem());
             }
         }
 
@@ -57,10 +55,9 @@ public class KafkaProducerExample {
         }
 
         KafkaProducer<String, String> producer = new KafkaProducer<>(props);
-        log.info("Sending {} messages ...", config.getMessageCount());
 
         boolean blockProducer = System.getenv("BLOCKING_PRODUCER") != null;
-        boolean transactionalProducer = Boolean.parseBoolean(props.getProperty(TRANSACTIONAL_ID_CONFIG));
+        boolean transactionalProducer = System.getenv("KAFKA_TRANSACTIONAL_ID") != null;
         int msgPerTx = Integer.parseInt(System.getenv().getOrDefault("MESSAGES_PER_TRANSACTION", "10"));
         if(transactionalProducer) {
             log.info("Using transactional producer. Initializing the transactions ...");


### PR DESCRIPTION
Refactor  Producer Config files in the Java client by reducing the complexity and size of the class. Standardise the naming scheme of environment variables used to configure the clients / standardise the envVars used to configure the Kafka client properties as outlined here [1].

Example of standardised Environmental Variables:

KAFKA_<NAME_OF_KAFKA_PROPERTY_DELIMITED_BY_UNDERSCORES>
[1] https://github.com/kyguy/proposals/blob/refactor-client-examples/040-refactor-client-examples.md