### PR TITLE
Refactor consumer yamls

### DIFF
--- a/java/kafka/deployment-oauth.yaml
+++ b/java/kafka/deployment-oauth.yaml
@@ -183,29 +183,6 @@ spec:
                   name: sso-x509-https-secret
                   key: tls.crt
 ---
-apiVersion: kafka.strimzi.io/v1beta1
-kind: KafkaUser
-metadata:
-  name: service-account-java-kafka-consumer
-  labels:
-    strimzi.io/cluster: my-cluster
-spec:
-  authorization:
-    type: simple
-    acls:
-      - resource:
-          type: topic
-          name: my-topic-reversed
-        operation: Read
-      - resource:
-          type: topic
-          name: my-topic-reversed
-        operation: Describe
-      - resource:
-          type: group
-          name: java-kafka-consumer
-        operation: Read
----
 apiVersion: v1
 kind: Secret
 metadata:
@@ -234,33 +211,48 @@ spec:
         - name: java-kafka-consumer
           image: quay.io/strimzi-examples/java-kafka-consumer:latest
           env:
-            - name: KAFKA_BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9092
             - name: STRIMZI_TOPIC
               value: my-topic-reversed
-            - name: KAFKA_GROUP_ID
-              value: java-kafka-consumer
             - name: STRIMZI_LOG_LEVEL
               value: "INFO"
             - name: STRIMZI_MESSAGE_COUNT
               value: "1000000"
-            - name: KAFKA_KEY_DESERIALIZER
-              value: "org.apache.kafka.common.serialization.StringDeserializer"
-            - name: KAFKA_VALUE_DESERIALIZER
-              value: "org.apache.kafka.common.serialization.StringDeserializer"
-            - name: KAFKA_OAUTH_CLIENT_ID
+            - name: OAUTH_CLIENT_ID
               value: java-kafka-consumer
-            - name: KAFKA_OAUTH_CLIENT_SECRET
+            - name: OAUTH_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: java-kafka-consumer-oauth
-                  key: clientSecret
+                  key: secret
             - name: OAUTH_TOKEN_ENDPOINT_URI
               value: https://sso.myproject.svc:8443/auth/realms/internal/protocol/openid-connect/token
-            - name: KAFKA_OAUTH_SSL_TRUSTSTORE_TYPE
+            - name: OAUTH_SSL_TRUSTSTORE_TYPE
               value: PEM
-            - name: KAFKA_OAUTH_SSL_TRUSTSTORE_CERTIFICATES
+            - name: OAUTH_SSL_TRUSTSTORE_CERTIFICATES
               valueFrom:
                 secretKeyRef:
                   name: sso-x509-https-secret
                   key: tls.crt
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9093
+            - name: KAFKA_GROUP_ID
+              value: java-kafka-consumer
+            - name: KAFKA_KEY_DESERIALIZER
+              value: "org.apache.kafka.common.serialization.StringDeserializer"
+            - name: KAFKA_VALUE_DESERIALIZER
+              value: "org.apache.kafka.common.serialization.StringDeserializer"
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: "SASL_SSL"
+            - name: KAFKA_SASL_JAAS_CONFIG
+              value: "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;"
+            - name: KAFKA_SASL_MECHANISM
+              value: OAUTHBEARER
+            - name: KAFKA_SASL_LOGIN_CALLBACK_HANDLER_CLASS
+              value: "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
+            - name: KAFKA_SSL_TRUSTSTORE_TYPE
+              value: PEM
+            - name: KAFKA_SSL_TRUSTSTORE_CERTIFICATES
+              valueFrom:
+                secretKeyRef:
+                  name: my-cluster-cluster-ca-cert
+                  key: ca.crt

--- a/java/kafka/deployment-ssl-auth.yaml
+++ b/java/kafka/deployment-ssl-auth.yaml
@@ -228,6 +228,20 @@ spec:
         - name: java-kafka-consumer
           image: quay.io/strimzi-examples/java-kafka-consumer:latest
           env:
+            - name: STRIMZI_TOPIC
+              value: my-topic-reversed
+            - name: STRIMZI_LOG_LEVEL
+              value: "INFO"
+            - name: STRIMZI_MESSAGE_COUNT
+              value: "1000000"
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9093
+            - name: KAFKA_GROUP_ID
+              value: java-kafka-consumer
+            - name: KAFKA_KEY_DESERIALIZER
+              value: "org.apache.kafka.common.serialization.StringDeserializer"
+            - name: KAFKA_VALUE_DESERIALIZER
+              value: "org.apache.kafka.common.serialization.StringDeserializer"
             - name: KAFKA_SECURITY_PROTOCOL
               value: SSL
             - name: KAFKA_SSL_TRUSTSTORE_CERTIFICATES
@@ -249,17 +263,3 @@ spec:
                   key: user.key
             - name: KAFKA_SSL_KEYSTORE_TYPE
               value: PEM
-            - name: KAFKA_BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9093
-            - name: STRIMZI_TOPIC
-              value: my-topic-reversed
-            - name: KAFKA_GROUP_ID
-              value: java-kafka-consumer
-            - name: STRIMZI_LOG_LEVEL
-              value: "INFO"
-            - name: STRIMZI_MESSAGE_COUNT
-              value: "1000000"
-            - name: KAFKA_KEY_DESERIALIZER
-              value: "org.apache.kafka.common.serialization.StringDeserializer"
-            - name: KAFKA_VALUE_DESERIALIZER
-              value: "org.apache.kafka.common.serialization.StringDeserializer"

--- a/java/kafka/deployment-ssl.yaml
+++ b/java/kafka/deployment-ssl.yaml
@@ -61,7 +61,6 @@ spec:
               value: SSL
             - name: KAFKA_SSL_TRUSTSTORE_TYPE
               value: PEM
-
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -119,26 +118,26 @@ spec:
         - name: java-kafka-consumer
           image: quay.io/strimzi-examples/java-kafka-consumer:latest
           env:
-            - name: KAFKA_SSL_TRUSTSTORE_CERTIFICATES
-              valueFrom:
-                secretKeyRef:
-                  name: my-cluster-cluster-ca-cert
-                  key: ca.crt
-            - name: KAFKA_SECURITY_PROTOCOL
-              value: SSL
-            - name: KAFKA_SSL_TRUSTSTORE_TYPE
-              value: PEM
-            - name: KAFKA_BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9093
             - name: STRIMZI_TOPIC
               value: my-topic-reversed
-            - name: KAFKA_GROUP_ID
-              value: java-kafka-consumer
             - name: STRIMZI_LOG_LEVEL
               value: "INFO"
             - name: STRIMZI_MESSAGE_COUNT
               value: "1000000"
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9093
+            - name: KAFKA_GROUP_ID
+              value: java-kafka-consumer
             - name: KAFKA_KEY_DESERIALIZER
               value: "org.apache.kafka.common.serialization.StringDeserializer"
             - name: KAFKA_VALUE_DESERIALIZER
               value: "org.apache.kafka.common.serialization.StringDeserializer"
+            - name: KAFKA_SSL_TRUSTSTORE_CERTIFICATES
+              valueFrom:
+                secretKeyRef:
+                  name: my-cluster-cluster-ca-cert
+                   key: ca.crt
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: SSL
+            - name: KAFKA_SSL_TRUSTSTORE_TYPE
+              value: PEM

--- a/java/kafka/deployment-tracing-jaeger.yaml
+++ b/java/kafka/deployment-tracing-jaeger.yaml
@@ -83,12 +83,12 @@ spec:
         - name: java-kafka-consumer
           image: quay.io/strimzi-examples/java-kafka-consumer:latest
           env:
+            - name: STRIMZI_TOPIC
+              value: my-topic-reversed
             - name: STRIMZI_LOG_LEVEL
               value: "INFO"
             - name: STRIMZI_MESSAGE_COUNT
               value: "1000000"
-            - name: STRIMZI_TOPIC
-              value: my-topic-reversed
             - name: STRIMZI_TRACING_SYSTEM
               value: jaeger
             - name: KAFKA_BOOTSTRAP_SERVERS

--- a/java/kafka/deployment-tracing-opentelemetry.yaml
+++ b/java/kafka/deployment-tracing-opentelemetry.yaml
@@ -124,16 +124,18 @@ spec:
         - name: java-kafka-consumer
           image: quay.io/strimzi-examples/java-kafka-consumer:latest
           env:
-            - name: KAFKA_BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9092
             - name: STRIMZI_TOPIC
               value: my-topic-reversed
-            - name: KAFKA_GROUP_ID
-              value: java-kafka-consumer
             - name: STRIMZI_LOG_LEVEL
               value: "INFO"
             - name: STRIMZI_MESSAGE_COUNT
               value: "1000000"
+            - name: STRIMZI_TRACING_SYSTEM
+              value: opentelemetry
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9092
+            - name: KAFKA_GROUP_ID
+              value: java-kafka-consumer
             - name: KAFKA_KEY_DESERIALIZER
               value: "org.apache.kafka.common.serialization.StringDeserializer"
             - name: KAFKA_VALUE_DESERIALIZER
@@ -146,5 +148,3 @@ spec:
               value: none
             - name: OTEL_EXPORTER_JAEGER_ENDPOINT
               value: http://my-jaeger-collector:14250
-            - name: STRIMZI_TRACING_SYSTEM
-              value: opentelemetry

--- a/java/kafka/deployment.yaml
+++ b/java/kafka/deployment.yaml
@@ -104,16 +104,16 @@ spec:
         - name: java-kafka-consumer
           image: quay.io/strimzi-examples/java-kafka-consumer:latest
           env:
-            - name: KAFKA_BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9092
             - name: STRIMZI_TOPIC
               value: my-topic-reversed
-            - name: KAFKA_GROUP_ID
-              value: java-kafka-consumer
             - name: STRIMZI_LOG_LEVEL
               value: "INFO"
             - name: STRIMZI_MESSAGE_COUNT
               value: "1000000"
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9092
+            - name: KAFKA_GROUP_ID
+              value: java-kafka-consumer
             - name: KAFKA_KEY_DESERIALIZER
               value: "org.apache.kafka.common.serialization.StringDeserializer"
             - name: KAFKA_VALUE_DESERIALIZER

--- a/java/kafka/java-kafka-consumer.yaml
+++ b/java/kafka/java-kafka-consumer.yaml
@@ -18,16 +18,16 @@ spec:
       - name: java-kafka-consumer
         image: quay.io/strimzi-examples/java-kafka-consumer:latest
         env:
-          - name: KAFKA_BOOTSTRAP_SERVERS
-            value: my-cluster-kafka-bootstrap:9092
           - name: STRIMZI_TOPIC
             value: my-topic
-          - name: KAFKA_GROUP_ID
-            value: my-java-kafka-consumer
           - name: STRIMZI_LOG_LEVEL
             value: "INFO"
           - name: STRIMZI_MESSAGE_COUNT
             value: "1000000"
+          - name: KAFKA_BOOTSTRAP_SERVERS
+            value: my-cluster-kafka-bootstrap:9092
+          - name: KAFKA_GROUP_ID
+            value: my-java-kafka-consumer
           - name: KAFKA_KEY_DESERIALIZER
             value: "org.apache.kafka.common.serialization.StringDeserializer"
           - name: KAFKA_VALUE_DESERIALIZER

--- a/java/kafka/producer/src/main/java/KafkaProducerExample.java
+++ b/java/kafka/producer/src/main/java/KafkaProducerExample.java
@@ -6,7 +6,6 @@
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.logging.log4j.Logger;
@@ -15,8 +14,6 @@ import org.apache.logging.log4j.LogManager;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class KafkaProducerExample {


### PR DESCRIPTION
Refactor the Consumer Yaml files so that they are in line with the Producer Deployments as seen here [1], by reordering the environment variables in the Yaml files to uniform categories.

[1] https://github.com/strimzi/client-examples/blob/main/java/kafka/deployment.yaml