### PR TITLE
Refactor Streams Configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,22 +73,14 @@ Consumer
 * `STRIMZI_LOG_LEVEL` - logging level  
 * `STRIMZI_TRACING_SYSTEM` - if it's set to `jaeger` or `opentelemetry`, this will enable tracing.
 
+Streams  
+* `STRIMZI_SOURCE_TOPIC` - name of topic which will be used as the source of messages
+* `STRIMZI_TARGET_TOPIC` - name of topic where the transformed images are sent
+* `STRIMZI_TRACING_SYSTEM` - if it's set to `jaeger` or `opentelemetry`, this will enable tracing.
+
 Additionally, any Kafka Consumer API or Kafka Producer API configuration option can be passed as an environment variable.
 It should be prefixed with `KAFKA_` and use `_` instead of `.`.
 For example environment variable `KAFKA_BOOTSTRAP_SERVERS` will be used as the `bootstrap.servers` configuration option in the Kafka Consumer API.
-
-Streams  
-* `BOOTSTRAP_SERVERS` - comma-separated host and port pairs that is a list of Kafka broker addresses. The form of pair is `host:port`, e.g. `my-cluster-kafka-bootstrap:9092`
-* `APPLICATION_ID` - The Kafka Streams application ID
-* `SOURCE_TOPIC` - name of topic which will be used as the source of messages
-* `TARGET_TOPIC` - name of topic where the transformed images are sent
-* `COMMIT_INTERVAL_MS` - the interval for the Kafka Streams consumer part committing the offsets
-* `CA_CRT` - the certificate of the CA which signed the brokers' TLS certificates, for adding to the client's trust store
-* `USER_CRT` - the user's certificate
-* `USER_KEY` - the user's private key
-* `LOG_LEVEL` - logging level
-* `ADDITIONAL_CONFIG` - additional configuration for a streams application. Notice, that you can also override any previously set variable by setting this. The form is `key=value` records separated by new line character.
-* `TRACING_SYSTEM` - if it's set to `jaeger` or `opentelemetry`, this will enable tracing.
 
 ### Tracing
 

--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ Consumer
 
 Streams  
 * `STRIMZI_SOURCE_TOPIC` - name of topic which will be used as the source of messages
-* `STRIMZI_TARGET_TOPIC` - name of topic where the transformed images are sent
+* `STRIMZI_TARGET_TOPIC` - name of topic where the transformed messages are sent
+* `STRIMZI_LOG_LEVEL` - logging level
 * `STRIMZI_TRACING_SYSTEM` - if it's set to `jaeger` or `opentelemetry`, this will enable tracing.
 
-Additionally, any Kafka Consumer API or Kafka Producer API configuration option can be passed as an environment variable.
+Additionally, any Kafka Consumer API, Kafka Producer API or Kafka Streams API configuration option can be passed as an environment variable.
 It should be prefixed with `KAFKA_` and use `_` instead of `.`.
 For example environment variable `KAFKA_BOOTSTRAP_SERVERS` will be used as the `bootstrap.servers` configuration option in the Kafka Consumer API.
 

--- a/java/kafka/consumer/src/main/resources/log4j2.properties
+++ b/java/kafka/consumer/src/main/resources/log4j2.properties
@@ -5,7 +5,7 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-rootLogger.level = ${env:LOG_LEVEL:-INFO}
+rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false

--- a/java/kafka/deployment-oauth.yaml
+++ b/java/kafka/deployment-oauth.yaml
@@ -92,42 +92,6 @@ spec:
                   name: my-cluster-cluster-ca-cert
                   key: ca.crt
 ---
-apiVersion: kafka.strimzi.io/v1beta1
-kind: KafkaUser
-metadata:
-  name: service-account-java-kafka-streams
-  labels:
-    strimzi.io/cluster: my-cluster
-spec:
-  authorization:
-    type: simple
-    acls:
-      - resource:
-          type: topic
-          name: my-topic
-        operation: Read
-      - resource:
-          type: topic
-          name: my-topic
-        operation: Describe
-      - resource:
-          type: group
-          name: java-kafka-streams
-          patternType: prefix
-        operation: Read
-      - resource:
-          type: topic
-          name: my-topic-reversed
-        operation: Write
-      - resource:
-          type: topic
-          name: my-topic-reversed
-        operation: Create
-      - resource:
-          type: topic
-          name: my-topic-reversed
-        operation: Describe
----
 apiVersion: v1
 kind: Secret
 metadata:
@@ -156,15 +120,11 @@ spec:
         - name: java-kafka-streams
           image: quay.io/strimzi-examples/java-kafka-streams:latest
           env:
-            - name: BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9092
-            - name: APPLICATION_ID
-              value: java-kafka-streams
-            - name: SOURCE_TOPIC
+            - name: STRIMZI_SOURCE_TOPIC
               value: my-topic
-            - name: TARGET_TOPIC
+            - name: STRIMZI_TARGET_TOPIC
               value: my-topic-reversed
-            - name: LOG_LEVEL
+            - name: STRIMZI_LOG_LEVEL
               value: "INFO"
             - name: OAUTH_CLIENT_ID
               value: java-kafka-streams
@@ -182,6 +142,31 @@ spec:
                 secretKeyRef:
                   name: sso-x509-https-secret
                   key: tls.crt
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9092
+            - name: KAFKA_APPLICATION_ID
+              value: java-kafka-streams
+            - name: KAFKA_DEFAULT_COMMIT_INTERVAL_MS
+              value: "5000"
+            - name: KAFKA_DEFAULT_KEY_SERDE
+              value: "org.apache.kafka.common.serialization.Serdes$StringSerde"
+            - name: KAFKA_DEFAULT_VALUE_SERDE
+              value: "org.apache.kafka.common.serialization.Serdes$StringSerde"
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: "SASL_SSL"
+            - name: KAFKA_SASL_JAAS_CONFIG
+              value: "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;"
+            - name: KAFKA_SASL_MECHANISM
+              value: OAUTHBEARER
+            - name: KAFKA_SASL_LOGIN_CALLBACK_HANDLER_CLASS
+              value: "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
+            - name: KAFKA_SSL_TRUSTSTORE_TYPE
+              value: PEM
+            - name: KAFKA_SSL_TRUSTSTORE_CERTIFICATES
+              valueFrom:
+                secretKeyRef:
+                  name: my-cluster-cluster-ca-cert
+                  key: ca.crt
 ---
 apiVersion: v1
 kind: Secret

--- a/java/kafka/deployment-ssl-auth.yaml
+++ b/java/kafka/deployment-ssl-auth.yaml
@@ -185,12 +185,12 @@ spec:
             - name: KAFKA_SSL_KEYSTORE_CERTIFICATE_CHAIN
               valueFrom:
                 secretKeyRef:
-                  name: java-kafka-producer
+                  name: java-kafka-streams
                   key: user.crt
             - name: KAFKA_SSL_KEYSTORE_KEY
               valueFrom:
                 secretKeyRef:
-                  name: java-kafka-producer
+                  name: java-kafka-streams
                   key: user.key
             - name: KAFKA_SSL_KEYSTORE_TYPE
               value: PEM

--- a/java/kafka/deployment-ssl-auth.yaml
+++ b/java/kafka/deployment-ssl-auth.yaml
@@ -157,31 +157,43 @@ spec:
         - name: java-kafka-streams
           image: quay.io/strimzi-examples/java-kafka-streams:latest
           env:
-            - name: CA_CRT
+            - name: STRIMZI_SOURCE_TOPIC
+              value: my-topic
+            - name: STRIMZI_TARGET_TOPIC
+              value: my-topic-reversed
+            - name: STRIMZI_LOG_LEVEL
+              value: "INFO"
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9093
+            - name: KAFKA_APPLICATION_ID
+              value: java-kafka-streams
+            - name: KAFKA_DEFAULT_COMMIT_INTERVAL_MS
+              value: "5000"
+            - name: KAFKA_DEFAULT_KEY_SERDE
+              value: "org.apache.kafka.common.serialization.Serdes$StringSerde"
+            - name: KAFKA_DEFAULT_VALUE_SERDE
+              value: "org.apache.kafka.common.serialization.Serdes$StringSerde"
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: SSL
+            - name: KAFKA_SSL_TRUSTSTORE_CERTIFICATES
               valueFrom:
                 secretKeyRef:
                   name: my-cluster-cluster-ca-cert
                   key: ca.crt
-            - name: USER_CRT
+            - name: KAFKA_SSL_TRUSTSTORE_TYPE
+              value: PEM
+            - name: KAFKA_SSL_KEYSTORE_CERTIFICATE_CHAIN
               valueFrom:
                 secretKeyRef:
-                  name: java-kafka-streams
+                  name: java-kafka-producer
                   key: user.crt
-            - name: USER_KEY
+            - name: KAFKA_SSL_KEYSTORE_KEY
               valueFrom:
                 secretKeyRef:
-                  name: java-kafka-streams
+                  name: java-kafka-producer
                   key: user.key
-            - name: BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9093
-            - name: APPLICATION_ID
-              value: java-kafka-streams
-            - name: SOURCE_TOPIC
-              value: my-topic
-            - name: TARGET_TOPIC
-              value: my-topic-reversed
-            - name: LOG_LEVEL
-              value: "INFO"
+            - name: KAFKA_SSL_KEYSTORE_TYPE
+              value: PEM
 ---
 apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaUser

--- a/java/kafka/deployment-ssl.yaml
+++ b/java/kafka/deployment-ssl.yaml
@@ -103,10 +103,10 @@ spec:
                 secretKeyRef:
                   name: my-cluster-cluster-ca-cert
                   key: ca.crt
-            - name: KAFKA_SECURITY_PROTOCOL
-              value: SSL
             - name: KAFKA_SSL_TRUSTSTORE_TYPE
               value: PEM
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: SSL
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/java/kafka/deployment-ssl.yaml
+++ b/java/kafka/deployment-ssl.yaml
@@ -82,21 +82,31 @@ spec:
         - name: java-kafka-streams
           image: quay.io/strimzi-examples/java-kafka-streams:latest
           env:
-            - name: CA_CRT
+            - name: STRIMZI_SOURCE_TOPIC
+              value: my-topic
+            - name: STRIMZI_TARGET_TOPIC
+              value: my-topic-reversed
+            - name: STRIMZI_LOG_LEVEL
+              value: "INFO"
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9093
+            - name: KAFKA_APPLICATION_ID
+              value: java-kafka-streams
+            - name: KAFKA_DEFAULT_COMMIT_INTERVAL_MS
+              value: "5000"
+            - name: KAFKA_DEFAULT_KEY_SERDE
+              value: "org.apache.kafka.common.serialization.Serdes$StringSerde"
+            - name: KAFKA_DEFAULT_VALUE_SERDE
+              value: "org.apache.kafka.common.serialization.Serdes$StringSerde"
+            - name: KAFKA_SSL_TRUSTSTORE_CERTIFICATES
               valueFrom:
                 secretKeyRef:
                   name: my-cluster-cluster-ca-cert
                   key: ca.crt
-            - name: BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9093
-            - name: APPLICATION_ID
-              value: java-kafka-streams
-            - name: SOURCE_TOPIC
-              value: my-topic
-            - name: TARGET_TOPIC
-              value: my-topic-reversed
-            - name: LOG_LEVEL
-              value: "INFO"
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: SSL
+            - name: KAFKA_SSL_TRUSTSTORE_TYPE
+              value: PEM
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -136,7 +146,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: my-cluster-cluster-ca-cert
-                   key: ca.crt
+                  key: ca.crt
             - name: KAFKA_SECURITY_PROTOCOL
               value: SSL
             - name: KAFKA_SSL_TRUSTSTORE_TYPE

--- a/java/kafka/deployment-tracing-jaeger.yaml
+++ b/java/kafka/deployment-tracing-jaeger.yaml
@@ -67,53 +67,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: java-kafka-streams
-  name: java-kafka-streams
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: java-kafka-streams
-  template:
-    metadata:
-      labels:
-        app: java-kafka-streams
-    spec:
-      containers:
-        - name: java-kafka-streams
-          image: quay.io/strimzi-examples/java-kafka-streams:latest
-          env:
-            - name: STRIMZI_SOURCE_TOPIC
-              value: my-topic
-            - name: STRIMZI_TARGET_TOPIC
-              value: my-topic-reversed
-            - name: STRIMZI_LOG_LEVEL
-              value: "INFO"
-            - name: STRIMZI_TRACING_SYSTEM
-              value: jaeger
-            - name: KAFKA_BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9092
-            - name: KAFKA_APPLICATION_ID
-              value: java-kafka-streams
-            - name: KAFKA_DEFAULT_COMMIT_INTERVAL_MS
-              value: "5000"
-            - name: KAFKA_DEFAULT_KEY_SERDE
-              value: "org.apache.kafka.common.serialization.Serdes$StringSerde"
-            - name: KAFKA_DEFAULT_VALUE_SERDE
-              value: "org.apache.kafka.common.serialization.Serdes$StringSerde"
-            - name: JAEGER_SERVICE_NAME
-              value: java-kafka-streams
-            - name: JAEGER_AGENT_HOST
-              value: my-jaeger-agent
-            - name: JAEGER_SAMPLER_TYPE
-              value: const
-            - name: JAEGER_SAMPLER_PARAM
-              value: "1"
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
     app: java-kafka-consumer
   name: java-kafka-consumer
 spec:

--- a/java/kafka/deployment-tracing-jaeger.yaml
+++ b/java/kafka/deployment-tracing-jaeger.yaml
@@ -67,6 +67,53 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app: java-kafka-streams
+  name: java-kafka-streams
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: java-kafka-streams
+  template:
+    metadata:
+      labels:
+        app: java-kafka-streams
+    spec:
+      containers:
+        - name: java-kafka-streams
+          image: quay.io/strimzi-examples/java-kafka-streams:latest
+          env:
+            - name: STRIMZI_SOURCE_TOPIC
+              value: my-topic
+            - name: STRIMZI_TARGET_TOPIC
+              value: my-topic-reversed
+            - name: STRIMZI_LOG_LEVEL
+              value: "INFO"
+            - name: STRIMZI_TRACING_SYSTEM
+              value: jaeger
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9092
+            - name: KAFKA_APPLICATION_ID
+              value: java-kafka-streams
+            - name: KAFKA_DEFAULT_COMMIT_INTERVAL_MS
+              value: "5000"
+            - name: KAFKA_DEFAULT_KEY_SERDE
+              value: "org.apache.kafka.common.serialization.Serdes$StringSerde"
+            - name: KAFKA_DEFAULT_VALUE_SERDE
+              value: "org.apache.kafka.common.serialization.Serdes$StringSerde"
+            - name: JAEGER_SERVICE_NAME
+              value: java-kafka-streams
+            - name: JAEGER_AGENT_HOST
+              value: my-jaeger-agent
+            - name: JAEGER_SAMPLER_TYPE
+              value: const
+            - name: JAEGER_SAMPLER_PARAM
+              value: "1"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
     app: java-kafka-consumer
   name: java-kafka-consumer
 spec:

--- a/java/kafka/deployment-tracing-opentelemetry.yaml
+++ b/java/kafka/deployment-tracing-opentelemetry.yaml
@@ -83,16 +83,24 @@ spec:
         - name: java-kafka-streams
           image: quay.io/strimzi-examples/java-kafka-streams:latest
           env:
-            - name: BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9092
-            - name: APPLICATION_ID
-              value: java-kafka-streams
-            - name: SOURCE_TOPIC
+            - name: STRIMZI_SOURCE_TOPIC
               value: my-topic
-            - name: TARGET_TOPIC
+            - name: STRIMZI_TARGET_TOPIC
               value: my-topic-reversed
-            - name: LOG_LEVEL
+            - name: STRIMZI_LOG_LEVEL
               value: "INFO"
+            - name: STRIMZI_TRACING_SYSTEM
+              value: opentelemetry
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9092
+            - name: KAFKA_APPLICATION_ID
+              value: java-kafka-streams
+            - name: KAFKA_DEFAULT_COMMIT_INTERVAL_MS
+              value: "5000"
+            - name: KAFKA_DEFAULT_KEY_SERDE
+              value: "org.apache.kafka.common.serialization.Serdes$StringSerde"
+            - name: KAFKA_DEFAULT_VALUE_SERDE
+              value: "org.apache.kafka.common.serialization.Serdes$StringSerde"
             - name: OTEL_SERVICE_NAME
               value: kafka-otel
             - name: OTEL_TRACES_EXPORTER
@@ -101,8 +109,6 @@ spec:
               value: none
             - name: OTEL_EXPORTER_JAEGER_ENDPOINT
               value: http://my-jaeger-collector:14250
-            - name: TRACING_SYSTEM
-              value: opentelemetry
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/java/kafka/deployment-tracing-opentelemetry.yaml
+++ b/java/kafka/deployment-tracing-opentelemetry.yaml
@@ -81,7 +81,7 @@ spec:
     spec:
       containers:
         - name: java-kafka-streams
-          image: quay.io/strimzi-examples/java-kafka-streams:latest
+          image: docker.io/owenerz/java-kafka-streams:latest
           env:
             - name: STRIMZI_SOURCE_TOPIC
               value: my-topic

--- a/java/kafka/deployment.yaml
+++ b/java/kafka/deployment.yaml
@@ -73,16 +73,22 @@ spec:
         - name: java-kafka-streams
           image: quay.io/strimzi-examples/java-kafka-streams:latest
           env:
-            - name: BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9092
-            - name: APPLICATION_ID
-              value: java-kafka-streams
-            - name: SOURCE_TOPIC
+            - name: STRIMZI_SOURCE_TOPIC
               value: my-topic
-            - name: TARGET_TOPIC
+            - name: STRIMZI_TARGET_TOPIC
               value: my-topic-reversed
-            - name: LOG_LEVEL
+            - name: STRIMZI_LOG_LEVEL
               value: "INFO"
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9092
+            - name: KAFKA_APPLICATION_ID
+              value: java-kafka-streams
+            - name: KAFKA_DEFAULT_COMMIT_INTERVAL_MS
+              value: "5000"
+            - name: KAFKA_DEFAULT_KEY_SERDE
+              value: "org.apache.kafka.common.serialization.Serdes$StringSerde"
+            - name: KAFKA_DEFAULT_VALUE_SERDE
+              value: "org.apache.kafka.common.serialization.Serdes$StringSerde"
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/java/kafka/java-kafka-streams.yaml
+++ b/java/kafka/java-kafka-streams.yaml
@@ -21,7 +21,7 @@ spec:
           - name: STRIMZI_SOURCE_TOPIC
             value: my-topic
           - name: STRIMZI_TARGET_TOPIC
-            value: my-topic-reversed
+            value: cipot-ym
           - name: STRIMZI_LOG_LEVEL
             value: "INFO"
           - name: KAFKA_BOOTSTRAP_SERVERS

--- a/java/kafka/java-kafka-streams.yaml
+++ b/java/kafka/java-kafka-streams.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: java-kafka-streams
-        image: quay.io/strimzi-examples/java-kafka-streams:latest
+        image: docker.io/owenerz/java-kafka-streams:latest
         env:
           - name: STRIMZI_SOURCE_TOPIC
             value: my-topic

--- a/java/kafka/java-kafka-streams.yaml
+++ b/java/kafka/java-kafka-streams.yaml
@@ -18,16 +18,19 @@ spec:
       - name: java-kafka-streams
         image: quay.io/strimzi-examples/java-kafka-streams:latest
         env:
-          - name: BOOTSTRAP_SERVERS
-            value: my-cluster-kafka-bootstrap:9092
-          - name: APPLICATION_ID
-            value: java-kafka-streams
-          - name: SOURCE_TOPIC
+          - name: STRIMZI_SOURCE_TOPIC
             value: my-topic
-          - name: TARGET_TOPIC
-            value: cipot-ym
-          - name: LOG_LEVEL
+          - name: STRIMZI_TARGET_TOPIC
+            value: my-topic-reversed
+          - name: STRIMZI_LOG_LEVEL
             value: "INFO"
-          - name: ADDITIONAL_CONFIG
-            value: |
-              retries=100
+          - name: KAFKA_BOOTSTRAP_SERVERS
+            value: my-cluster-kafka-bootstrap:9092
+          - name: KAFKA_APPLICATION_ID
+            value: java-kafka-streams
+          - name: KAFKA_DEFAULT_COMMIT_INTERVAL_MS
+            value: "5000"
+          - name: KAFKA_DEFAULT_KEY_SERDE
+            value: "org.apache.kafka.common.serialization.Serdes$StringSerde"
+          - name: KAFKA_DEFAULT_VALUE_SERDE
+            value: "org.apache.kafka.common.serialization.Serdes$StringSerde"

--- a/java/kafka/producer/src/main/resources/log4j2.properties
+++ b/java/kafka/producer/src/main/resources/log4j2.properties
@@ -5,7 +5,7 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-rootLogger.level = ${env:LOG_LEVEL:-INFO}
+rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false

--- a/java/kafka/streams/src/main/java/KafkaStreamsConfig.java
+++ b/java/kafka/streams/src/main/java/KafkaStreamsConfig.java
@@ -3,213 +3,65 @@
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 
-import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.common.config.SaslConfigs;
-import org.apache.kafka.common.config.SslConfigs;
-import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.StreamsConfig;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
+import java.util.Map;
 import java.util.Properties;
-import java.util.StringTokenizer;
+import java.util.stream.Collectors;
 
 public class KafkaStreamsConfig {
-    private static final Logger log = LogManager.getLogger(KafkaStreamsConfig.class);
 
-    private static final int DEFAULT_COMMIT_INTERVAL_MS = 5000;
-    private final String bootstrapServers;
-    private final String applicationId;
+    private static final String KAFKA_PREFIX = "KAFKA_";
+
     private final String sourceTopic;
     private final String targetTopic;
-    private final int commitIntervalMs;
-    private final String sslTruststoreCertificates;
-    private final String sslKeystoreKey;
-    private final String sslKeystoreCertificateChain;
-    private final String oauthClientId;
-    private final String oauthClientSecret;
-    private final String oauthAccessToken;
-    private final String oauthRefreshToken;
-    private final String oauthTokenEndpointUri;
-    private final String additionalConfig;
-    private final String saslLoginCallbackClass = "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler";
     private final TracingSystem tracingSystem;
+    private final Properties properties;
 
-    public KafkaStreamsConfig(String bootstrapServers, String applicationId, String sourceTopic, String targetTopic,
-                              int commitIntervalMs, String sslTruststoreCertificates, String sslKeystoreKey, String sslKeystoreCertificateChain,
-                              String oauthClientId, String oauthClientSecret, String oauthAccessToken, String oauthRefreshToken,
-                              String oauthTokenEndpointUri, String additionalConfig, TracingSystem tracingSystem) {
-        this.bootstrapServers = bootstrapServers;
-        this.applicationId = applicationId;
+    public KafkaStreamsConfig(String sourceTopic, String targetTopic,
+                              TracingSystem tracingSystem, Properties properties) {
         this.sourceTopic = sourceTopic;
         this.targetTopic = targetTopic;
-        this.commitIntervalMs = commitIntervalMs;
-        this.sslTruststoreCertificates = sslTruststoreCertificates;
-        this.sslKeystoreKey = sslKeystoreKey;
-        this.sslKeystoreCertificateChain = sslKeystoreCertificateChain;
-        this.oauthClientId = oauthClientId;
-        this.oauthClientSecret = oauthClientSecret;
-        this.oauthAccessToken = oauthAccessToken;
-        this.oauthRefreshToken = oauthRefreshToken;
-        this.oauthTokenEndpointUri = oauthTokenEndpointUri;
-        this.additionalConfig = additionalConfig;
         this.tracingSystem = tracingSystem;
+        this.properties = properties;
     }
 
     public static KafkaStreamsConfig fromEnv() {
-        String bootstrapServers = System.getenv("BOOTSTRAP_SERVERS");
-        String sourceTopic = System.getenv("SOURCE_TOPIC");
-        String targetTopic = System.getenv("TARGET_TOPIC");
-        String applicationId = System.getenv("APPLICATION_ID");
-        int commitIntervalMs = System.getenv("COMMIT_INTERVAL_MS") == null ? DEFAULT_COMMIT_INTERVAL_MS : Integer.parseInt(System.getenv("COMMIT_INTERVAL_MS"));
-        String sslTruststoreCertificates = System.getenv("CA_CRT");
-        String sslKeystoreKey = System.getenv("USER_KEY");
-        String sslKeystoreCertificateChain = System.getenv("USER_CRT");
-        String oauthClientId = System.getenv("OAUTH_CLIENT_ID");
-        String oauthClientSecret = System.getenv("OAUTH_CLIENT_SECRET");
-        String oauthAccessToken = System.getenv("OAUTH_ACCESS_TOKEN");
-        String oauthRefreshToken = System.getenv("OAUTH_REFRESH_TOKEN");
-        String oauthTokenEndpointUri = System.getenv("OAUTH_TOKEN_ENDPOINT_URI");
-        String additionalConfig = System.getenv().getOrDefault("ADDITIONAL_CONFIG", "");
-        TracingSystem tracingSystem = TracingSystem.forValue(System.getenv().getOrDefault("TRACING_SYSTEM", ""));
-
-        return new KafkaStreamsConfig(bootstrapServers, applicationId, sourceTopic, targetTopic, commitIntervalMs,
-                sslTruststoreCertificates, sslKeystoreKey, sslKeystoreCertificateChain, oauthClientId, oauthClientSecret,
-                oauthAccessToken, oauthRefreshToken, oauthTokenEndpointUri, additionalConfig, tracingSystem);
+        String sourceTopic = System.getenv("STRIMZI_SOURCE_TOPIC");
+        String targetTopic = System.getenv("STRIMZI_TARGET_TOPIC");
+        TracingSystem tracingSystem = TracingSystem.forValue(System.getenv().getOrDefault("STRIMZI_TRACING_SYSTEM", ""));
+        Properties properties = new Properties();
+        properties.putAll(System.getenv()
+                .entrySet()
+                .stream()
+                .filter(mapEntry -> mapEntry.getKey().startsWith(KAFKA_PREFIX))
+                .collect(Collectors.toMap(mapEntry -> convertEnvVarToPropertyKey(mapEntry.getKey()), Map.Entry::getValue)));
+        return new KafkaStreamsConfig( sourceTopic, targetTopic, tracingSystem, properties);
     }
 
-    public static Properties createProperties(KafkaStreamsConfig config) {
-        Properties props = new Properties();
-
-        props.put(StreamsConfig.APPLICATION_ID_CONFIG, config.getApplicationId());
-        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBootstrapServers());
-        props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, config.getCommitInterval());
-        props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
-        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
-
-        if (config.getSslTruststoreCertificates() != null)   {
-            log.info("Configuring truststore");
-            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
-            props.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PEM");
-            props.put(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, config.getSslTruststoreCertificates());
-        }
-
-        if (config.getSslKeystoreCertificateChain() != null && config.getSslKeystoreKey() != null)   {
-            log.info("Configuring keystore");
-            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
-            props.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PEM");
-            props.put(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, config.getSslKeystoreCertificateChain());
-            props.put(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, config.getSslKeystoreKey());
-        }
-
-        Properties additionalProps = new Properties();
-        if (!config.getAdditionalConfig().isEmpty()) {
-            StringTokenizer tok = new StringTokenizer(config.getAdditionalConfig(), System.lineSeparator());
-            while (tok.hasMoreTokens()) {
-                String record = tok.nextToken();
-                int endIndex = record.indexOf('=');
-                if (endIndex == -1) {
-                    throw new RuntimeException("Failed to parse Map from String");
-                }
-                String key = record.substring(0, endIndex);
-                String value = record.substring(endIndex + 1);
-                additionalProps.put(key.trim(), value.trim());
-            }
-        }
-
-        if ((config.getOauthAccessToken() != null)
-                || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthRefreshToken() != null)
-                || (config.getOauthTokenEndpointUri() != null && config.getOauthClientId() != null && config.getOauthClientSecret() != null))    {
-            log.info("Configuring OAuth");
-            props.put(SaslConfigs.SASL_JAAS_CONFIG, "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;");
-            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL".equals(props.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)) ? "SASL_SSL" : "SASL_PLAINTEXT");
-            props.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
-            if (!(additionalProps.containsKey(SaslConfigs.SASL_MECHANISM) && additionalProps.getProperty(SaslConfigs.SASL_MECHANISM).equals("PLAIN"))) {
-                props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, config.saslLoginCallbackClass);
-            }
-        }
-
-        // override properties with defined additional properties
-        props.putAll(additionalProps);
-
-        return props;
-    }
-    public String getBootstrapServers() {
-        return bootstrapServers;
-    }
-
-    public String getApplicationId() {
-        return applicationId;
+    private static String convertEnvVarToPropertyKey(String envVar) {
+        return envVar.substring(envVar.indexOf("_") + 1).toLowerCase().replace("_", ".");
     }
 
     public String getSourceTopic() {
         return sourceTopic;
     }
-
     public String getTargetTopic() {
         return targetTopic;
     }
-
-    public int getCommitInterval() {
-        return commitIntervalMs;
+    public TracingSystem getTracingSystem() {
+        return tracingSystem;
     }
 
-    public String getSslTruststoreCertificates() {
-        return sslTruststoreCertificates;
+    public Properties getProperties() {
+        return properties;
     }
-
-    public String getSslKeystoreKey() {
-        return sslKeystoreKey;
-    }
-
-    public String getSslKeystoreCertificateChain() {
-        return sslKeystoreCertificateChain;
-    }
-
-    public String getOauthClientId() {
-        return oauthClientId;
-    }
-
-    public String getOauthClientSecret() {
-        return oauthClientSecret;
-    }
-
-    public String getOauthAccessToken() {
-        return oauthAccessToken;
-    }
-
-    public String getOauthRefreshToken() {
-        return oauthRefreshToken;
-    }
-
-    public String getOauthTokenEndpointUri() {
-        return oauthTokenEndpointUri;
-    }
-
-    public String getAdditionalConfig() {
-        return additionalConfig;
-    }
-
-    public TracingSystem getTracingSystem() { return tracingSystem;  }
 
     @Override
     public String toString() {
         return "KafkaStreamsConfig{" +
-            "bootstrapServers='" + bootstrapServers + '\'' +
-            ", applicationId='" + applicationId + '\'' +
-            ", sourceTopic='" + sourceTopic + '\'' +
-            ", targetTopic='" + targetTopic + '\'' +
-            ", commitIntervalMs=" + commitIntervalMs +
-            ", sslTruststoreCertificates='" + sslTruststoreCertificates + '\'' +
-            ", sslKeystoreKey='" + sslKeystoreKey + '\'' +
-            ", sslKeystoreCertificateChain='" + sslKeystoreCertificateChain + '\'' +
-            ", oauthClientId='" + oauthClientId + '\'' +
-            ", oauthClientSecret='" + oauthClientSecret + '\'' +
-            ", oauthAccessToken='" + oauthAccessToken + '\'' +
-            ", oauthRefreshToken='" + oauthRefreshToken + '\'' +
-            ", oauthTokenEndpointUri='" + oauthTokenEndpointUri + '\'' +
-            ", additionalConfig='" + additionalConfig + '\'' +
-            ", tracingSystem='" + tracingSystem + '\'' +
-            '}';
+                ", sourceTopic='" + sourceTopic + '\'' +
+                ", targetTopic='" + targetTopic + '\'' +
+                ", tracingSystem='" + tracingSystem + '\'' +
+                ", properties ='" + properties + '\'' +
+                '}';
     }
 }

--- a/java/kafka/streams/src/main/java/KafkaStreamsExample.java
+++ b/java/kafka/streams/src/main/java/KafkaStreamsExample.java
@@ -23,7 +23,7 @@ public class KafkaStreamsExample {
 
         log.info(KafkaStreamsConfig.class.getName() + ": {}",  config.toString());
 
-        Properties props = KafkaStreamsConfig.createProperties(config);
+        Properties props = config.getProperties();
 
         StreamsBuilder builder = new StreamsBuilder();
 
@@ -46,7 +46,7 @@ public class KafkaStreamsExample {
                 KafkaClientSupplier supplier = new TracingKafkaClientSupplier();
                 streams = new KafkaStreams(builder.build(), props, supplier);
             } else {
-                throw new RuntimeException("Error: TRACING_SYSTEM " + tracingSystem + " is not recognized or supported!");
+                throw new RuntimeException("Error: STRIMZI_TRACING_SYSTEM " + tracingSystem + " is not recognized or supported!");
             }
         } else {
             streams = new KafkaStreams(builder.build(), props);

--- a/java/kafka/streams/src/main/java/KafkaStreamsExample.java
+++ b/java/kafka/streams/src/main/java/KafkaStreamsExample.java
@@ -7,7 +7,6 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.logging.log4j.Logger;
@@ -40,8 +39,6 @@ public class KafkaStreamsExample {
         TracingSystem tracingSystem = config.getTracingSystem();
         if (tracingSystem != TracingSystem.NONE) {
             if (tracingSystem == TracingSystem.OPENTELEMETRY) {
-                props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
-                props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
 
                 KafkaClientSupplier supplier = new TracingKafkaClientSupplier();
                 streams = new KafkaStreams(builder.build(), props, supplier);

--- a/java/kafka/streams/src/main/resources/log4j2.properties
+++ b/java/kafka/streams/src/main/resources/log4j2.properties
@@ -5,7 +5,7 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-rootLogger.level = ${env:LOG_LEVEL:-INFO}
+rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false


### PR DESCRIPTION
Refactor the Streams Config files in the Java client by reducing the complexity and size of the class. Standardise the naming scheme of environment variables used to configure the clients / standardise the environment variables used to configure the Kafka client properties as outlined here [1].

Example of standardised Environmental Variables:

KAFKA_<NAME_OF_KAFKA_PROPERTY_DELIMITED_BY_UNDERSCORES>
[1] https://github.com/kyguy/proposals/blob/refactor-client-examples/040-refactor-client-examples.md