### PR TITLE
Fix registry in  yamls

### DIFF
--- a/java/kafka/deployment-tracing-opentelemetry.yaml
+++ b/java/kafka/deployment-tracing-opentelemetry.yaml
@@ -81,7 +81,7 @@ spec:
     spec:
       containers:
         - name: java-kafka-streams
-          image: docker.io/owenerz/java-kafka-streams:latest
+          image: quay.io/strimzi-examples/java-kafka-streams:latest
           env:
             - name: STRIMZI_SOURCE_TOPIC
               value: my-topic

--- a/java/kafka/java-kafka-streams.yaml
+++ b/java/kafka/java-kafka-streams.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: java-kafka-streams
-        image: docker.io/owenerz/java-kafka-streams:latest
+        image: quay.io/strimzi-examples/java-kafka-streams:latest
         env:
           - name: STRIMZI_SOURCE_TOPIC
             value: my-topic


### PR DESCRIPTION
Wrong registry in Yaml files ```java-kafka-streams.yaml```  and ```java/kafka/deployment-tracing-opentelemetry.yaml```. Reverted to quay.io. 