### PR TITLE
Override Jackson Databind dependency due to old Vert.x version

### DIFF
--- a/http/vertx/java-http-vertx-consumer/pom.xml
+++ b/http/vertx/java-http-vertx-consumer/pom.xml
@@ -58,6 +58,15 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
         </dependency>
+        <!--
+            Override Jackson Databind dependency due to an old Vert.x version
+            which doesn't work with latest Jackson Databind version from the parent pom
+         -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.8</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/http/vertx/java-http-vertx-producer/pom.xml
+++ b/http/vertx/java-http-vertx-producer/pom.xml
@@ -58,6 +58,15 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
         </dependency>
+        <!--
+            Override Jackson Databind dependency due to an old Vert.x version
+            which doesn't work with latest Jackson Databind version from the parent pom
+         -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.8</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,8 @@
                                     <ignoredUnusedDeclaredDependency>io.opentelemetry:opentelemetry-exporter-jaeger</ignoredUnusedDeclaredDependency>
                                     <ignoredUnusedDeclaredDependency>io.opentelemetry:opentelemetry-exporter-otlp</ignoredUnusedDeclaredDependency>
                                     <ignoredUnusedDeclaredDependency>io.strimzi:kafka-oauth-client</ignoredUnusedDeclaredDependency>
+                                    <!-- Due to the override in the Vert.x HTTP client examples -->
+                                    <ignoredUnusedDeclaredDependency>com.fasterxml.jackson.core:jackson-databind</ignoredUnusedDeclaredDependency>
                                 </ignoredUnusedDeclaredDependencies>
                             </configuration>
                         </execution>


### PR DESCRIPTION
The latest PR #105 about adding the Java SDK HTTP client examples, added a direct dependency to Jackson Databind:

```xml
<jackson-databind.version>2.13.4.2</jackson-databind.version>
```

This version broke the Vert.x HTTP client examples because they use a really old Vert.x version, the 3.7.1.
The error I get when starting them is the following:

```shell
Exception in thread "main" java.lang.NoClassDefFoundError: com/fasterxml/jackson/core/util/JacksonFeature
	at com.fasterxml.jackson.databind.ObjectMapper.<init>(ObjectMapper.java:674)
	at com.fasterxml.jackson.databind.ObjectMapper.<init>(ObjectMapper.java:576)
	at io.vertx.core.json.Json.<clinit>(Json.java:43)
	at io.vertx.core.json.JsonObject.put(JsonObject.java:684)
	at io.vertx.config.spi.utils.JsonObjectHelper.put(JsonObjectHelper.java:45)
	at io.vertx.config.impl.spi.EnvVariablesConfigStore.lambda$all$0(EnvVariablesConfigStore.java:78)
	at java.base/java.util.Map.forEach(Map.java:716)
	at java.base/java.util.Collections$UnmodifiableMap.forEach(Collections.java:1553)
	at io.vertx.config.impl.spi.EnvVariablesConfigStore.all(EnvVariablesConfigStore.java:76)
	at io.vertx.config.impl.spi.EnvVariablesConfigStore.get(EnvVariablesConfigStore.java:68)
	at io.vertx.config.impl.ConfigurationProvider.get(ConfigurationProvider.java:60)
	at io.vertx.config.impl.ConfigRetrieverImpl.lambda$compute$7(ConfigRetrieverImpl.java:262)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at io.vertx.config.impl.ConfigRetrieverImpl.compute(ConfigRetrieverImpl.java:271)
	at io.vertx.config.impl.ConfigRetrieverImpl.getConfig(ConfigRetrieverImpl.java:173)
	at ConsumerApp.main(ConsumerApp.java:43)
Caused by: java.lang.ClassNotFoundException: com.fasterxml.jackson.core.util.JacksonFeature
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	... 22 more
```

This PR fixes the issue by defining a direct dependency to the old Jackson Databind dependency in order to use that for Vert.x examples.
For now, I think we can fix this way.
A long term solution should be upgrading Vert.x to latest 4.3.7 but it needs a refactoring because of big differences (i.e. uses of Promise instead of Future, verticle definition and more).
