### PR TITLE
Replace OpenTelemetry Jaeger exporter with the default OTLP exporter

### DIFF
--- a/java/kafka/consumer/pom.xml
+++ b/java/kafka/consumer/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-jaeger</artifactId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>

--- a/java/kafka/deployment-tracing-opentelemetry.yaml
+++ b/java/kafka/deployment-tracing-opentelemetry.yaml
@@ -56,12 +56,10 @@ spec:
               value: "org.apache.kafka.common.serialization.StringSerializer"
             - name: OTEL_SERVICE_NAME
               value: kafka-otel
-            - name: OTEL_TRACES_EXPORTER
-              value: jaeger
             - name: OTEL_METRICS_EXPORTER
               value: none
-            - name: OTEL_EXPORTER_JAEGER_ENDPOINT
-              value: http://my-jaeger-collector:14250
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://my-jaeger-collector:4317
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -103,12 +101,10 @@ spec:
               value: "org.apache.kafka.common.serialization.Serdes$StringSerde"
             - name: OTEL_SERVICE_NAME
               value: kafka-otel
-            - name: OTEL_TRACES_EXPORTER
-              value: jaeger
             - name: OTEL_METRICS_EXPORTER
               value: none
-            - name: OTEL_EXPORTER_JAEGER_ENDPOINT
-              value: http://my-jaeger-collector:14250
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://my-jaeger-collector:4317
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -148,9 +144,7 @@ spec:
               value: "org.apache.kafka.common.serialization.StringDeserializer"
             - name: OTEL_SERVICE_NAME
               value: kafka-otel
-            - name: OTEL_TRACES_EXPORTER
-              value: jaeger
             - name: OTEL_METRICS_EXPORTER
               value: none
-            - name: OTEL_EXPORTER_JAEGER_ENDPOINT
-              value: http://my-jaeger-collector:14250
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://my-jaeger-collector:4317

--- a/java/kafka/deployment-tracing-opentelemetry.yaml
+++ b/java/kafka/deployment-tracing-opentelemetry.yaml
@@ -59,7 +59,7 @@ spec:
             - name: OTEL_METRICS_EXPORTER
               value: none
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://my-otlp-collector:4317
+              value: http://my-otlp-endpoint:4317
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -104,7 +104,7 @@ spec:
             - name: OTEL_METRICS_EXPORTER
               value: none
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://my-otlp-collector:4317
+              value: http://my-otlp-endpoint:4317
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -147,4 +147,4 @@ spec:
             - name: OTEL_METRICS_EXPORTER
               value: none
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://my-otlp-collector:4317
+              value: http://my-otlp-endpoint:4317

--- a/java/kafka/deployment-tracing-opentelemetry.yaml
+++ b/java/kafka/deployment-tracing-opentelemetry.yaml
@@ -59,7 +59,7 @@ spec:
             - name: OTEL_METRICS_EXPORTER
               value: none
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://my-jaeger-collector:4317
+              value: http://my-otlp-collector:4317
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -104,7 +104,7 @@ spec:
             - name: OTEL_METRICS_EXPORTER
               value: none
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://my-jaeger-collector:4317
+              value: http://my-otlp-collector:4317
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -147,4 +147,4 @@ spec:
             - name: OTEL_METRICS_EXPORTER
               value: none
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://my-jaeger-collector:4317
+              value: http://my-otlp-collector:4317

--- a/java/kafka/producer/pom.xml
+++ b/java/kafka/producer/pom.xml
@@ -38,7 +38,7 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-jaeger</artifactId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>

--- a/java/kafka/streams/pom.xml
+++ b/java/kafka/streams/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-jaeger</artifactId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -143,11 +143,6 @@
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry</groupId>
-                <artifactId>opentelemetry-exporter-jaeger</artifactId>
-                <version>${opentelemetry.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-exporter-otlp</artifactId>
                 <version>${opentelemetry.version}</version>
             </dependency>
@@ -178,7 +173,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <build>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
This PR fixes #102
Strimzi components have already moved to use the OTLP exporter (instead of the Jaeger one) for the OpenTelemetry support.
The client-examples should do the same, as it is the default.
Replace opentelemetry-exporter-jaeger dependency with the opentelemetry-exporter-otlp dependency.
Remove OTEL_TRACES_EXPORTER env var in the YAMLs because OTLP is the default protocol for OpenTelemetry. 
Replace OTEL_EXPORTER_JAEGER_ENDPOINT with OTEL_EXPORTER_OTLP_ENDPOINT env var, using port 4317.
