### PR TITLE
Refactor groupId from strimzi.io to io.strimzi in POMs

### DIFF
--- a/java/common/pom.xml
+++ b/java/common/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>strimzi.io</groupId>
+        <groupId>io.strimzi</groupId>
         <artifactId>java-examples</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>

--- a/java/http/java-http-consumer/pom.xml
+++ b/java/http/java-http-consumer/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>strimzi.io</groupId>
+        <groupId>io.strimzi</groupId>
         <artifactId>java-http-examples</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
@@ -33,7 +33,7 @@
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>strimzi.io</groupId>
+            <groupId>io.strimzi</groupId>
             <artifactId>common</artifactId>
         </dependency>
         <dependency>

--- a/java/http/java-http-producer/pom.xml
+++ b/java/http/java-http-producer/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>strimzi.io</groupId>
+        <groupId>io.strimzi</groupId>
         <artifactId>java-http-examples</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
@@ -25,7 +25,7 @@
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>strimzi.io</groupId>
+            <groupId>io.strimzi</groupId>
             <artifactId>common</artifactId>
         </dependency>
         <dependency>

--- a/java/http/pom.xml
+++ b/java/http/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>strimzi.io</groupId>
+        <groupId>io.strimzi</groupId>
         <artifactId>java-examples</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>

--- a/java/http/vertx/java-http-vertx-consumer/pom.xml
+++ b/java/http/vertx/java-http-vertx-consumer/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     
     <parent>
-        <groupId>strimzi.io</groupId>
+        <groupId>io.strimzi</groupId>
         <artifactId>java-http-vertx-examples</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>

--- a/java/http/vertx/java-http-vertx-producer/pom.xml
+++ b/java/http/vertx/java-http-vertx-producer/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     
     <parent>
-        <groupId>strimzi.io</groupId>
+        <groupId>io.strimzi</groupId>
         <artifactId>java-http-vertx-examples</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>

--- a/java/http/vertx/pom.xml
+++ b/java/http/vertx/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>strimzi.io</groupId>
+        <groupId>io.strimzi</groupId>
         <artifactId>java-http-examples</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>

--- a/java/kafka/consumer/pom.xml
+++ b/java/kafka/consumer/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>strimzi.io</groupId>
+        <groupId>io.strimzi</groupId>
         <artifactId>java-kafka-examples</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
@@ -13,7 +13,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>strimzi.io</groupId>
+            <groupId>io.strimzi</groupId>
             <artifactId>common</artifactId>
         </dependency>
         <dependency>

--- a/java/kafka/pom.xml
+++ b/java/kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>strimzi.io</groupId>
+        <groupId>io.strimzi</groupId>
         <artifactId>java-examples</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>

--- a/java/kafka/producer/pom.xml
+++ b/java/kafka/producer/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 

--- a/java/kafka/producer/pom.xml
+++ b/java/kafka/producer/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>strimzi.io</groupId>
+        <groupId>io.strimzi</groupId>
         <artifactId>java-kafka-examples</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
@@ -13,7 +13,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>strimzi.io</groupId>
+            <groupId>io.strimzi</groupId>
             <artifactId>common</artifactId>
         </dependency>
         <dependency>

--- a/java/kafka/streams/pom.xml
+++ b/java/kafka/streams/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>strimzi.io</groupId>
+        <groupId>io.strimzi</groupId>
         <artifactId>java-kafka-examples</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
@@ -13,7 +13,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>strimzi.io</groupId>
+            <groupId>io.strimzi</groupId>
             <artifactId>common</artifactId>
         </dependency>
         <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>strimzi.io</groupId>
+        <groupId>io.strimzi</groupId>
         <artifactId>client-examples</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>strimzi.io</groupId>
+    <groupId>io.strimzi</groupId>
     <artifactId>client-examples</artifactId>
     <packaging>pom</packaging>
     <version>1.0-SNAPSHOT</version>
@@ -41,7 +41,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>strimzi.io</groupId>
+                <groupId>io.strimzi</groupId>
                 <artifactId>common</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Maven build groupId was `strimzi.io` throughout the POM files. It is now refactored to the correct `io.strimzi` groupId. 