### PR TITLE
Found typo in OAuth EnvVar

### DIFF
--- a/java/kafka/deployment-oauth.yaml
+++ b/java/kafka/deployment-oauth.yaml
@@ -60,7 +60,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: java-kafka-producer-oauth
-                  key: secret
+                  key: clientSecret
             - name: OAUTH_TOKEN_ENDPOINT_URI
               value: https://sso.myproject.svc:8443/auth/realms/internal/protocol/openid-connect/token
             - name: OAUTH_SSL_TRUSTSTORE_TYPE
@@ -208,7 +208,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: java-kafka-consumer-oauth
-                  key: secret
+                  key: clientSecret
             - name: OAUTH_TOKEN_ENDPOINT_URI
               value: https://sso.myproject.svc:8443/auth/realms/internal/protocol/openid-connect/token
             - name: OAUTH_SSL_TRUSTSTORE_TYPE


### PR DESCRIPTION
While looking at the OAuth deployment YAML in Java/Kafka examples, in preparation to test using OAuth 0.12.0, an  error was noticed in `deployment-oauth.yaml`. The `OAUTH_CLIENT_SECRET`  environment variable key in the producer and consumer was set to `secret` instead of `clientSecret`. This error must have been included accidentally in a previous PR. This PR fixes the error.