### PR TITLE
Update OAuth to version 0.12.0

### DIFF
--- a/java/kafka/deployment-oauth.yaml
+++ b/java/kafka/deployment-oauth.yaml
@@ -71,7 +71,7 @@ spec:
                   name: sso-x509-https-secret
                   key: tls.crt
             - name: KAFKA_BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9092
+              value: my-cluster-kafka-bootstrap:9093
             - name: KAFKA_KEY_SERIALIZER
               value: "org.apache.kafka.common.serialization.StringSerializer"
             - name: KAFKA_VALUE_SERIALIZER
@@ -143,7 +143,7 @@ spec:
                   name: sso-x509-https-secret
                   key: tls.crt
             - name: KAFKA_BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9092
+              value: my-cluster-kafka-bootstrap:9093
             - name: KAFKA_APPLICATION_ID
               value: java-kafka-streams
             - name: KAFKA_DEFAULT_COMMIT_INTERVAL_MS
@@ -219,7 +219,7 @@ spec:
                   name: sso-x509-https-secret
                   key: tls.crt
             - name: KAFKA_BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9092
+              value: my-cluster-kafka-bootstrap:9093
             - name: KAFKA_GROUP_ID
               value: java-kafka-consumer
             - name: KAFKA_KEY_DESERIALIZER

--- a/java/kafka/deployment-oauth.yaml
+++ b/java/kafka/deployment-oauth.yaml
@@ -71,7 +71,7 @@ spec:
                   name: sso-x509-https-secret
                   key: tls.crt
             - name: KAFKA_BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9093
+              value: my-cluster-kafka-bootstrap:9092
             - name: KAFKA_KEY_SERIALIZER
               value: "org.apache.kafka.common.serialization.StringSerializer"
             - name: KAFKA_VALUE_SERIALIZER
@@ -219,7 +219,7 @@ spec:
                   name: sso-x509-https-secret
                   key: tls.crt
             - name: KAFKA_BOOTSTRAP_SERVERS
-              value: my-cluster-kafka-bootstrap:9093
+              value: my-cluster-kafka-bootstrap:9092
             - name: KAFKA_GROUP_ID
               value: java-kafka-consumer
             - name: KAFKA_KEY_DESERIALIZER

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <opentelemetry-alpha.version>1.19.0-alpha</opentelemetry-alpha.version>
         <opentelemetry.version>1.19.0</opentelemetry.version>
         <jaeger.version>1.1.0</jaeger.version>
-        <strimzi-oauth-callback.version>0.8.1</strimzi-oauth-callback.version>
+        <strimzi-oauth-callback.version>0.12.0</strimzi-oauth-callback.version>
         <vertx.version>4.3.7</vertx.version>
         <netty.version>4.1.87.Final</netty.version>
         <jackson-databind.version>2.13.4.2</jackson-databind.version>


### PR DESCRIPTION
Bump OAuth from version 0.8.1 to version 0.12.0. OAuth tested with Keycloak and working. OpenTelemetry and Jaeger tested and working with the updated version 0.12.0.