### PR TITLE
bump kafka version to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <spotbugs.version>4.7.3</spotbugs.version>
         <maven.spotbugs.version>4.7.3.0</maven.spotbugs.version>
         <!-- Regular dependencies -->
-        <kafka.version>3.4.0</kafka.version>
+        <kafka.version>3.5.0</kafka.version>
         <log4j.version>2.17.1</log4j.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>


### PR DESCRIPTION
Bumping Kafka version from 3.4.0 to 3.5.0 to keep in line with `strimzi-kafka-bridge` and `strimzi-kafka-operator`.