### PR TITLE
Fix broken HTTP client example YAMLs

### DIFF
--- a/java/http/deployment-tracing-opentelemetry.yaml
+++ b/java/http/deployment-tracing-opentelemetry.yaml
@@ -66,7 +66,7 @@ spec:
             value: "8080"
           - name: STRIMZI_TOPIC
             value: my-topic
-          - name: STRIMZI_GROUPID
+          - name: STRIMZI_GROUP_ID
             value: "my-group"
           - name: STRIMZI_POLL_INTERVAL
             value: "1000"

--- a/java/http/java-http-consumer.yaml
+++ b/java/http/java-http-consumer.yaml
@@ -24,9 +24,9 @@ spec:
             value: "8080"
           - name: STRIMZI_TOPIC
             value: my-topic
-          - name: STRIMZI_CLIENTID
+          - name: STRIMZI_CLIENT_ID
             value: "my-consumer"
-          - name: STRIMZI_GROUPID
+          - name: STRIMZI_GROUP_ID
             value: "my-group"
           - name: STRIMZI_POLL_INTERVAL
             value: "1000"

--- a/java/http/vertx/deployment-tracing.yaml
+++ b/java/http/vertx/deployment-tracing.yaml
@@ -71,7 +71,7 @@ spec:
             value: "8080"
           - name: STRIMZI_TOPIC
             value: my-topic
-          - name: STRIMZI_GROUPID
+          - name: STRIMZI_GROUP_ID
             value: "my-group"
           - name: STRIMZI_POLL_INTERVAL
             value: "1000"

--- a/java/http/vertx/java-http-vertx-consumer.yaml
+++ b/java/http/vertx/java-http-vertx-consumer.yaml
@@ -18,17 +18,17 @@ spec:
       - name: java-http-vertx-consumer
         image: quay.io/strimzi-examples/java-http-vertx-consumer:latest
         env:
-          - name: HOSTNAME
+          - name: STRIMZI_HOSTNAME
             value: my-bridge-bridge-service
-          - name: PORT
+          - name: STRIMZI_PORT
             value: "8080"
-          - name: TOPIC
+          - name: STRIMZI_TOPIC
             value: my-topic
-          - name: CLIENTID
+          - name: STRIMZI_CLIENT_ID
             value: "my-consumer"
-          - name: GROUPID
+          - name: STRIMZI_GROUP_ID
             value: "my-group"
-          - name: POLL_INTERVAL
+          - name: STRIMZI_POLL_INTERVAL
             value: "1000"
         resources:
           requests:

--- a/java/http/vertx/java-http-vertx-producer.yaml
+++ b/java/http/vertx/java-http-vertx-producer.yaml
@@ -18,13 +18,13 @@ spec:
       - name: java-http-vertx-producer
         image: quay.io/strimzi-examples/java-http-vertx-producer:latest
         env:
-          - name: HOSTNAME
+          - name: STRIMZI_HOSTNAME
             value: my-bridge-bridge-service
-          - name: PORT
+          - name: STRIMZI_PORT
             value: "8080"
-          - name: TOPIC
+          - name: STRIMZI_TOPIC
             value: my-topic
-          - name: SEND_INTERVAL
+          - name: STRIMZI_SEND_INTERVAL
             value: "1000"
         resources:
           requests:


### PR DESCRIPTION
This PR fixes the broker YAML examples for the HTTP clients that seem to be missing the prefixes or underscores.