### PR TITLE
Update Kafka, Vert.x and Netty dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,14 +32,14 @@
         <maven.spotbugs.version>4.7.3.0</maven.spotbugs.version>
 
         <!-- Regular dependencies -->
-        <kafka.version>3.6.1</kafka.version>
+        <kafka.version>3.7.0</kafka.version>
         <log4j.version>2.17.2</log4j.version>
         <slf4j.version>1.7.36</slf4j.version>
         <opentelemetry-alpha.version>1.19.0-alpha</opentelemetry-alpha.version>
         <opentelemetry.version>1.19.0</opentelemetry.version>
-        <strimzi-oauth-callback.version>0.14.0</strimzi-oauth-callback.version>
-        <vertx.version>4.5.1</vertx.version>
-        <netty.version>4.1.103.Final</netty.version>
+        <strimzi-oauth-callback.version>0.15.0</strimzi-oauth-callback.version>
+        <vertx.version>4.5.7</vertx.version>
+        <netty.version>4.1.108.Final</netty.version>
         <jackson-databind.version>2.15.3</jackson-databind.version>
     </properties>
 


### PR DESCRIPTION
This PR updates the Vert.x, Kafka and Netty dependencies (Vert.x and Netty have CVEs, so we should update them).