### PR TITLE
Update dependencies and minor fixes and improvements

### DIFF
--- a/java/http/java-http-consumer/Dockerfile
+++ b/java/http/java-http-consumer/Dockerfile
@@ -7,7 +7,7 @@ RUN microdnf update \
     && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/jre-17
+ENV JAVA_HOME=/usr/lib/jvm/jre-17
 
 # Add strimzi user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage

--- a/java/http/java-http-consumer/src/main/java/HttpConsumer.java
+++ b/java/http/java-http-consumer/src/main/java/HttpConsumer.java
@@ -102,8 +102,12 @@ public class HttpConsumer {
 
     public Map<String, Object> createConsumerConfig(Properties props) {
         Map<String, Object> consumerConfig = new HashMap<>();
-        consumerConfig.put("name", "my-consumer");
         consumerConfig.put("format", "json");
+
+        if (config.getClientId() != null) {
+            consumerConfig.put("name", config.getClientId());
+        }
+
         for (String k : commonProps) {
             if (props.stringPropertyNames().contains(k)) {
                 String v = props.getProperty(k);

--- a/java/http/java-http-producer/Dockerfile
+++ b/java/http/java-http-producer/Dockerfile
@@ -7,7 +7,7 @@ RUN microdnf update \
     && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/jre-17
+ENV JAVA_HOME=/usr/lib/jvm/jre-17
 
 # Add strimzi user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage

--- a/java/http/vertx/java-http-vertx-consumer/Dockerfile
+++ b/java/http/vertx/java-http-vertx-consumer/Dockerfile
@@ -7,7 +7,7 @@ RUN microdnf update \
     && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/jre-17
+ENV JAVA_HOME=/usr/lib/jvm/jre-17
 
 # Add strimzi user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage

--- a/java/http/vertx/java-http-vertx-producer/Dockerfile
+++ b/java/http/vertx/java-http-vertx-producer/Dockerfile
@@ -7,7 +7,7 @@ RUN microdnf update \
     && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/jre-17
+ENV JAVA_HOME=/usr/lib/jvm/jre-17
 
 # Add strimzi user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage

--- a/java/kafka/consumer/Dockerfile
+++ b/java/kafka/consumer/Dockerfile
@@ -7,7 +7,7 @@ RUN microdnf update \
     && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/jre-17
+ENV JAVA_HOME=/usr/lib/jvm/jre-17
 
 # Add strimzi user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage

--- a/java/kafka/producer/Dockerfile
+++ b/java/kafka/producer/Dockerfile
@@ -7,7 +7,7 @@ RUN microdnf update \
     && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/jre-17
+ENV JAVA_HOME=/usr/lib/jvm/jre-17
 
 # Add strimzi user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage

--- a/java/kafka/streams/Dockerfile
+++ b/java/kafka/streams/Dockerfile
@@ -7,7 +7,7 @@ RUN microdnf update \
     && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/jre-17
+ENV JAVA_HOME=/usr/lib/jvm/jre-17
 
 # Add strimzi user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage

--- a/pom.xml
+++ b/pom.xml
@@ -32,15 +32,15 @@
         <maven.spotbugs.version>4.7.3.0</maven.spotbugs.version>
 
         <!-- Regular dependencies -->
-        <kafka.version>3.7.0</kafka.version>
+        <kafka.version>3.8.0</kafka.version>
         <log4j.version>2.17.2</log4j.version>
         <slf4j.version>1.7.36</slf4j.version>
         <opentelemetry-alpha.version>1.19.0-alpha</opentelemetry-alpha.version>
         <opentelemetry.version>1.19.0</opentelemetry.version>
         <strimzi-oauth-callback.version>0.15.0</strimzi-oauth-callback.version>
-        <vertx.version>4.5.7</vertx.version>
-        <netty.version>4.1.108.Final</netty.version>
-        <jackson-databind.version>2.15.3</jackson-databind.version>
+        <vertx.version>4.5.9</vertx.version>
+        <netty.version>4.1.111.Final</netty.version>
+        <jackson-databind.version>2.16.1</jackson-databind.version>
     </properties>
 
     <dependencyManagement>

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -8,7 +8,4 @@ fi
 # Make sure that we use /dev/urandom
 JAVA_OPTS="${JAVA_OPTS} -Dvertx.cacheDirBase=/tmp/vertx-cache -Djava.security.egd=file:/dev/./urandom"
 
-# Enable GC logging for memory tracking
-JAVA_OPTS="${JAVA_OPTS} -Xlog:gc*:stdout:time -XX:NativeMemoryTracking=summary"
-
 exec java $JAVA_OPTS -jar $JAR "$@"


### PR DESCRIPTION
This PR updates the dependencies of the client examples. It also does some minor fixes / improvements:
* Updated the Dockerfiles to not use the deprecated `ENV` syntax
* Fixes the Java HTTP Consumer example to properly configure the consumer name
* Disables the Garbage collection logging that seems disrupting the log output of the running containers and does not seem to add any value to the examples