### PR TITLE
Reduce duplicaion in config files

### DIFF
--- a/java/common/src/main/java/io/strimzi/common/ConfigUtil.java
+++ b/java/common/src/main/java/io/strimzi/common/ConfigUtil.java
@@ -5,11 +5,17 @@
 package io.strimzi.common;
 
 import java.util.Locale;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.Map;
+
 
 /**
  * Provides utility methods for managing common configuration properties.
  */
 public class ConfigUtil {
+    private static final String KAFKA_PREFIX = "KAFKA_";
+
     /**
      * Converts environment variables into a corresponding property key format.
      *
@@ -18,5 +24,22 @@ public class ConfigUtil {
      */
     public static String convertEnvVarToPropertyKey(String envVar) {
         return envVar.substring(envVar.indexOf("_") + 1).toLowerCase(Locale.ENGLISH).replace("_", ".");
+    }
+
+    /**
+     * Retrieves Kafka-related properties from environment variables.
+     * This method scans all environment variables, filters those that start with the prefix "KAFKA_",
+     * converts them to a property key format, and collects them into a Properties object.
+     *
+     * @return Properties object containing Kafka-related properties derived from environment variables.
+     */
+    public static Properties getKafkaPropertiesFromEnv() {
+        Properties properties = new Properties();
+        properties.putAll(System.getenv()
+                .entrySet()
+                .stream()
+                .filter(mapEntry -> mapEntry.getKey().startsWith(KAFKA_PREFIX))
+                .collect(Collectors.toMap(mapEntry -> convertEnvVarToPropertyKey(mapEntry.getKey()), Map.Entry::getValue)));
+        return properties;
     }
 }

--- a/java/http/java-http-consumer/src/main/java/HttpConsumerConfig.java
+++ b/java/http/java-http-consumer/src/main/java/HttpConsumerConfig.java
@@ -2,7 +2,6 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-
 import io.strimzi.common.ConfigUtil;
 import io.strimzi.common.TracingSystem;
 

--- a/java/http/java-http-consumer/src/main/java/HttpConsumerConfig.java
+++ b/java/http/java-http-consumer/src/main/java/HttpConsumerConfig.java
@@ -2,12 +2,11 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
+
 import io.strimzi.common.ConfigUtil;
 import io.strimzi.common.TracingSystem;
 
-import java.util.Map;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 public class HttpConsumerConfig {
 
@@ -59,12 +58,7 @@ public class HttpConsumerConfig {
         int pollInterval = System.getenv("STRIMZI_POLL_INTERVAL") == null ? DEFAULT_POLL_INTERVAL : Integer.parseInt(System.getenv("STRIMZI_POLL_INTERVAL"));
         int pollTimeout = System.getenv("STRIMZI_POLL_TIMEOUT") == null ? DEFAULT_POLL_TIMEOUT : Integer.parseInt(System.getenv("STRIMZI_POLL_TIMEOUT"));
         TracingSystem tracingSystem = TracingSystem.forValue(System.getenv().getOrDefault("STRIMZI_TRACING_SYSTEM", ""));
-        Properties properties = new Properties();
-        properties.putAll(System.getenv()
-                .entrySet()
-                .stream()
-                .filter(mapEntry -> mapEntry.getKey().startsWith(KAFKA_PREFIX))
-                .collect(Collectors.toMap(mapEntry -> ConfigUtil.convertEnvVarToPropertyKey(mapEntry.getKey()), Map.Entry::getValue)));
+        Properties properties = ConfigUtil.getKafkaPropertiesFromEnv();
         return new HttpConsumerConfig(hostName, port, topic, groupId, clientId, messageCount, pollInterval, pollTimeout, tracingSystem, properties);
     }
 

--- a/java/kafka/consumer/src/main/java/io/strimzi/kafka/consumer/KafkaConsumerConfig.java
+++ b/java/kafka/consumer/src/main/java/io/strimzi/kafka/consumer/KafkaConsumerConfig.java
@@ -7,14 +7,10 @@ package io.strimzi.kafka.consumer;
 import io.strimzi.common.ConfigUtil;
 import io.strimzi.common.TracingSystem;
 
-import java.util.Map;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 public class KafkaConsumerConfig {
     private static final long DEFAULT_MESSAGES_COUNT = 10;
-    private static final String KAFKA_PREFIX = "KAFKA_";
-
     private final String topic;
     private final Long messageCount;
     private final TracingSystem tracingSystem;
@@ -31,12 +27,7 @@ public class KafkaConsumerConfig {
         String topic = System.getenv("STRIMZI_TOPIC");
         Long messageCount = System.getenv("STRIMZI_MESSAGE_COUNT") == null ? DEFAULT_MESSAGES_COUNT : Long.parseLong(System.getenv("STRIMZI_MESSAGE_COUNT"));
         TracingSystem tracingSystem = TracingSystem.forValue(System.getenv().getOrDefault("STRIMZI_TRACING_SYSTEM", ""));
-        Properties properties = new Properties();
-        properties.putAll(System.getenv()
-                .entrySet()
-                .stream()
-                .filter(mapEntry -> mapEntry.getKey().startsWith(KAFKA_PREFIX))
-                .collect(Collectors.toMap(mapEntry -> ConfigUtil.convertEnvVarToPropertyKey(mapEntry.getKey()), Map.Entry::getValue)));
+        Properties properties = ConfigUtil.getKafkaPropertiesFromEnv();
         return new KafkaConsumerConfig(topic, messageCount, tracingSystem, properties);
     }
 

--- a/java/kafka/producer/src/main/java/io/strimzi/kafka/producer/KafkaProducerConfig.java
+++ b/java/kafka/producer/src/main/java/io/strimzi/kafka/producer/KafkaProducerConfig.java
@@ -7,16 +7,12 @@ package io.strimzi.kafka.producer;
 import io.strimzi.common.ConfigUtil;
 import io.strimzi.common.TracingSystem;
 
-import java.util.Map;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 public class KafkaProducerConfig {
 
     private static final long DEFAULT_MESSAGES_COUNT = 10;
     private static final String DEFAULT_MESSAGE = "Hello world";
-    private static final String KAFKA_PREFIX = "KAFKA_";
-
     private final String topic;
     private final Long messageCount;
     private final int delay;
@@ -44,12 +40,7 @@ public class KafkaProducerConfig {
         String message = System.getenv("STRIMZI_MESSAGE") == null ? DEFAULT_MESSAGE : System.getenv("STRIMZI_MESSAGE");
         String headers = System.getenv("STRIMZI_HEADERS");
         TracingSystem tracingSystem = TracingSystem.forValue(System.getenv().getOrDefault("STRIMZI_TRACING_SYSTEM", ""));
-        Properties properties = new Properties();
-        properties.putAll(System.getenv()
-                .entrySet()
-                .stream()
-                .filter(mapEntry -> mapEntry.getKey().startsWith(KAFKA_PREFIX))
-                .collect(Collectors.toMap(mapEntry -> ConfigUtil.convertEnvVarToPropertyKey(mapEntry.getKey()), Map.Entry::getValue)));
+        Properties properties = ConfigUtil.getKafkaPropertiesFromEnv();
         return new KafkaProducerConfig(topic, messageCount, delay, message, headers, tracingSystem, properties);
     }
 

--- a/java/kafka/streams/src/main/java/io/strimzi/kafka/streams/KafkaStreamsConfig.java
+++ b/java/kafka/streams/src/main/java/io/strimzi/kafka/streams/KafkaStreamsConfig.java
@@ -7,13 +7,9 @@ package io.strimzi.kafka.streams;
 import io.strimzi.common.ConfigUtil;
 import io.strimzi.common.TracingSystem;
 
-import java.util.Map;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 public class KafkaStreamsConfig {
-
-    private static final String KAFKA_PREFIX = "KAFKA_";
 
     private final String sourceTopic;
     private final String targetTopic;
@@ -32,12 +28,7 @@ public class KafkaStreamsConfig {
         String sourceTopic = System.getenv("STRIMZI_SOURCE_TOPIC");
         String targetTopic = System.getenv("STRIMZI_TARGET_TOPIC");
         TracingSystem tracingSystem = TracingSystem.forValue(System.getenv().getOrDefault("STRIMZI_TRACING_SYSTEM", ""));
-        Properties properties = new Properties();
-        properties.putAll(System.getenv()
-                .entrySet()
-                .stream()
-                .filter(mapEntry -> mapEntry.getKey().startsWith(KAFKA_PREFIX))
-                .collect(Collectors.toMap(mapEntry -> ConfigUtil.convertEnvVarToPropertyKey(mapEntry.getKey()), Map.Entry::getValue)));
+        Properties properties = ConfigUtil.getKafkaPropertiesFromEnv();
         return new KafkaStreamsConfig(sourceTopic, targetTopic, tracingSystem, properties);
     }
 


### PR DESCRIPTION
This PR reduces use of duplicate code in the the Kafka config files by exctracting the `Properties` config to `ConfigUtils` class.