### PR TITLE
Update Netty and other dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,14 +32,14 @@
         <maven.spotbugs.version>4.7.3.0</maven.spotbugs.version>
 
         <!-- Regular dependencies -->
-        <kafka.version>3.8.0</kafka.version>
+        <kafka.version>3.9.0</kafka.version>
         <log4j.version>2.17.2</log4j.version>
         <slf4j.version>1.7.36</slf4j.version>
         <opentelemetry-alpha.version>1.19.0-alpha</opentelemetry-alpha.version>
         <opentelemetry.version>1.19.0</opentelemetry.version>
         <strimzi-oauth-callback.version>0.15.0</strimzi-oauth-callback.version>
-        <vertx.version>4.5.9</vertx.version>
-        <netty.version>4.1.111.Final</netty.version>
+        <vertx.version>4.5.11</vertx.version>
+        <netty.version>4.1.115.Final</netty.version>
         <jackson-databind.version>2.16.1</jackson-databind.version>
     </properties>
 


### PR DESCRIPTION
This PR updates Netty to 4.1.115 to address a CVE. And uses this opportunity to also update Vert.x and Kafka.