### PR TITLE
Bumped Vert.x 5 for Vert.x HTTP based examples

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,8 +101,8 @@
         <opentelemetry-alpha.version>1.19.0-alpha</opentelemetry-alpha.version>
         <opentelemetry.version>1.19.0</opentelemetry.version>
         <strimzi-oauth-callback.version>0.15.0</strimzi-oauth-callback.version>
-        <vertx.version>4.5.11</vertx.version>
-        <netty.version>4.1.115.Final</netty.version>
+        <vertx.version>5.0.1</vertx.version>
+        <netty.version>4.2.2.Final</netty.version>
         <jackson-databind.version>2.16.1</jackson-databind.version>
     </properties>
 


### PR DESCRIPTION
This PR bumps the Vert.x version to 5.x and adapt the code to use the Future and not callbacks.