### PR TITLE
Pass syft version properly do shared action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Install Syft
         uses: strimzi/github-actions/.github/actions/dependencies/install-syft@main
         with:
-          version: "v1.20.0"
+          version: "1.20.0"
 
       - name: Push containers using push-containers action
         uses: strimzi/github-actions/.github/actions/build/push-containers@main


### PR DESCRIPTION
I added prefix `v` into Syft version which is not correct and we hit it after mergin into main. This PR resolves it.